### PR TITLE
Display notice for need to run "sync to user login" script

### DIFF
--- a/src/assets/js/settings.js
+++ b/src/assets/js/settings.js
@@ -1,17 +1,5 @@
-jQuery(function ($) {
+jQuery(document).ready(function ($) {
     // Tabs
-    $hiddenFields = $('input[id^="ppma-tab-"]');
-
-    $hiddenFields.each(function () {
-        var $this = $(this);
-        var $wrapper = $this.next('table');
-        $wrapper.attr('id', $this.attr('id'));
-        $this.remove();
-
-        if ($wrapper.attr('id') !== 'ppma-tab-general') {
-            $wrapper.hide();
-        }
-    });
 
     var $tabsWrapper = $('#publishpress-authors-settings-tabs');
     $tabsWrapper.find('li').click(function (e) {
@@ -24,4 +12,43 @@ jQuery(function ($) {
         $('table[id^="ppma-"]').hide();
         $(panel).show();
     });
+
+    var ppmaTab = 'ppma-tab-general';
+
+    if (typeof ppmaSettings != 'undefined' && typeof ppmaSettings.tab != 'undefined') {
+       ppmaTab = ppmaSettings.tab;
+       $('#publishpress-authors-settings-tabs a[href="#' + ppmaTab + '"]').click();
+    }
+
+    $hiddenFields = $('input[id^="ppma-tab-"]');
+
+    $hiddenFields.each(function () {
+        var $this = $(this);
+        var $wrapper = $this.next('table');
+        $wrapper.attr('id', $this.attr('id'));
+        $this.remove();
+
+        if ($wrapper.attr('id') !== ppmaTab) {
+            $wrapper.hide();
+        }
+    });
+
+    if ('ppma-tab-maintenance' == ppmaTab) {
+        if (typeof ppmaSettings.runScript != 'undefined') {
+            switch (ppmaSettings.runScript) {
+                case 'sync-user-login':
+                    var intSyncUserLogin = setInterval( function() {
+                        if ($('#publishpress-authors-sync-author-slug div input').length) {
+                            $('#publishpress-authors-sync-author-slug div input').click();
+
+                            clearInterval(intSyncUserLogin);
+                        }
+                    }, 100);
+
+                    break;
+
+                default:
+            }
+        }
+    }
 });

--- a/src/modules/modules-settings/modules-settings.php
+++ b/src/modules/modules-settings/modules-settings.php
@@ -173,12 +173,10 @@ if (!class_exists('MA_Modules_Settings')) {
                 $tabs = apply_filters('publishpress_multiple_authors_settings_tabs', []);
                 if (!empty($tabs)) {
                     echo '<ul id="publishpress-authors-settings-tabs" class="nav-tab-wrapper">';
-                    $i = 0;
                     foreach ($tabs as $tabLink => $tabLabel) {
-                        echo '<li class="nav-tab ' . ($i === 0 ? 'nav-tab-active' : '') . '">';
+                        echo '<li class="nav-tab ' . ($tabLink === '#ppma-tab-general' ? 'nav-tab-active' : '') . '">';
                         echo '<a href="' . $tabLink . '">' . $tabLabel . '</a>';
                         echo '</li>';
-                        $i++;
                     }
                     echo '</ul>';
                 }

--- a/src/modules/multiple-authors/multiple-authors.php
+++ b/src/modules/multiple-authors/multiple-authors.php
@@ -2278,7 +2278,8 @@ if (!class_exists('MA_Multiple_Authors')) {
             }
 
             // Display the notice on Authors and Permissions plugin screens
-            $is_pp_plugin_page = isset($_GET['page']) && in_array($_GET['page'], ['ppma-modules-settings', 'presspermit-settings', 'presspermit-groups']);
+            $is_pp_plugin_page = (isset($_GET['page']) && in_array($_GET['page'], ['ppma-modules-settings', 'presspermit-settings', 'presspermit-groups']))
+            || ('edit-tags.php' == $pagenow && !empty($_REQUEST['taxonomy']) && ('author' == $_REQUEST['taxonomy']));
 
             $requirements = [
                 in_array($pagenow, ['plugins.php', 'edit.php', 'edit-tags.php']),
@@ -2297,7 +2298,7 @@ if (!class_exists('MA_Multiple_Authors')) {
 
             // Sync script already run
             if (get_option('publishpress_multiple_authors_usernicename_sync')) {
-                return;
+                //return;
             }
 
             // Notice is non-dismissible on Authors and Permissions plugin screens
@@ -2305,7 +2306,7 @@ if (!class_exists('MA_Multiple_Authors')) {
 
             // This notice is not forced, and has been dismissed
             if (!$ignore_dismissal && get_option('publishpress_authors_dismiss_permissions_sync_notice') == 1) {
-                return;
+               // return;
             }
 
             // User cannot run this script

--- a/src/modules/multiple-authors/multiple-authors.php
+++ b/src/modules/multiple-authors/multiple-authors.php
@@ -2132,8 +2132,6 @@ if (!class_exists('MA_Multiple_Authors')) {
 
             set_transient('publishpress_authors_sync_author_slug_ids', $termToSync, 24 * 60 * 60);
 
-            update_option('publishpress_multiple_authors_usernicename_sync', 1);
-
             wp_send_json(
                 [
                     'success'       => true,
@@ -2198,6 +2196,8 @@ if (!class_exists('MA_Multiple_Authors')) {
             }
 
             delete_transient('publishpress_authors_sync_author_slug_ids');
+
+            update_option('publishpress_multiple_authors_usernicename_sync', 1);
 
             wp_send_json(
                 [
@@ -2291,7 +2291,7 @@ if (!class_exists('MA_Multiple_Authors')) {
                 return;
             }
 
-            // This request is launching Sync script directly 
+            // This request is launching Sync script directly
             if (!empty($_REQUEST['ppma_maint']) && ('ppma_maint=sync-user-login' == $_REQUEST['ppma_maint'])) {
                 return;
             }

--- a/src/modules/multiple-authors/multiple-authors.php
+++ b/src/modules/multiple-authors/multiple-authors.php
@@ -2298,7 +2298,7 @@ if (!class_exists('MA_Multiple_Authors')) {
 
             // Sync script already run
             if (get_option('publishpress_multiple_authors_usernicename_sync')) {
-                //return;
+                return;
             }
 
             // Notice is non-dismissible on Authors and Permissions plugin screens
@@ -2306,7 +2306,7 @@ if (!class_exists('MA_Multiple_Authors')) {
 
             // This notice is not forced, and has been dismissed
             if (!$ignore_dismissal && get_option('publishpress_authors_dismiss_permissions_sync_notice') == 1) {
-               // return;
+                return;
             }
 
             // User cannot run this script


### PR DESCRIPTION
The notice displays a link to run the maintenance script directly.

## Description
Display an admin notice if the user is running PublishPress Permissions >= 3.4 but has not yet run the "Sync Authors to User Logins" maintenance script.

## Benefits
Permissions 3.4 adds posts query integration, giving multiple author assignments the same access advantages as the conventional post_author assignment.  However, this integration requires Authors to be stored slug equal to user_nicename (a sanitized version of user_login). The user will be alerted to the need, and we will avoid needless support requests.  After script execution, a flag is stored to the option table to prevent the notice from being displayed again.

The notice displays as dismissible on the Plugins, Posts and Tags screens, non-dismissible on the Authors and Permissions plugin screens.  It is only shown to users who have access to the Authors Settings screen.

## Possible drawbacks
None, except the user has to click one link to make the annoying notice go away.

## Applicable issues
The direct execution of the script from the notice link should be tested.

## Checklist
- [X] I have created a specific branch for this pull request before committing, starting off the current HEAD of `development` branch. 
- [X] I'm submitting to the `development`, feature/hotfix/release branch. (Do not submit to the master branch!)
- [X] This pull request relates to a specific problem (bug or improvement).
- [ ] I have mentioned the issue number in the pull request description text.
- [X] All the issues mentioned in this pull request relate to the problem I'm trying to solve.
- [X] The code I'm sending follows the [PSR-12](https://www.php-fig.org/psr/psr-12/) coding style.

![image](https://user-images.githubusercontent.com/43488774/101824481-404daf00-3afa-11eb-9121-637194dc708c.png)

![image](https://user-images.githubusercontent.com/43488774/101824519-4fccf800-3afa-11eb-8de2-d5684095bf39.png)

![image](https://user-images.githubusercontent.com/43488774/101825010-0b8e2780-3afb-11eb-88c4-d17129a6741b.png)

![image](https://user-images.githubusercontent.com/43488774/101825129-34162180-3afb-11eb-86e8-0cf03fb53bd4.png)

