### PR TITLE
Nested Pages plugin: PHP Warnings

### DIFF
--- a/src/core/Plugin.php
+++ b/src/core/Plugin.php
@@ -437,6 +437,25 @@ class Plugin
      */
     public function action_init_late()
     {
+        // Avoid PHP Warnings with Nested Pages plugin due to unexpected object variable type in $post->post_author array
+        // Also hide the Author selector in the NP modal until we develop an integration
+        //
+        // see NestedPages\Entities\Post\PostRepository\getTaxonomyCSS()
+        if (is_admin() && !empty($_REQUEST['page']) && ('nestedpages' == $_REQUEST['page'])) {
+            add_action(
+                'admin_print_scripts', 
+                function() {
+                    ?>
+                    <style type="text/css">
+                        div.np-inline-modal div.np_author {display:none;}
+                    </style>
+                    <?php
+                }
+            );
+
+            return;
+        }
+
         // Register new taxonomy so that we can store all of the relationships
         $args = [
             'labels'             => [


### PR DESCRIPTION
## Description
Each page on the Nested Pages screen yields a PHP Warning:

Warning: Invalid argument supplied for foreach() in F:\www\wp56\wp-content\plugins\wp-nested-pages\app\Entities\Post\PostRepository.php on line 71

Inspection of the Nested Pages code indicates that the $post->post_author property is expected to be an array of integers, but is actually an array of objects:

$terms = $post->$taxname; foreach ( $terms as $term ){ $out .= 'inf-' . $taxonomy->name . '-nps-' . $term . ' '; }

Don't register the post_author taxonomy on the Nested Pages screen. Hide the Author display/selector in the NP modal.

## Benefits
Eliminate PHP Warnings on the Nested Pages screen.

## Possible drawbacks
Unsatisfied expectations for Nested Pages who cannot set Author / Authors in the NP modal, until we develop an integration.

## Applicable issues
https://github.com/publishpress/PublishPress-Authors/issues/345

## Checklist

- [X] I have created a specific branch for this pull request before committing, starting off the current HEAD of `development` branch. 
- [X] I'm submitting to the `development`, feature/hotfix/release branch. (Do not submit to the master branch!)
- [X] This pull request relates to a specific problem (bug or improvement).
- [X] I have mentioned the issue number in the pull request description text.
- [X] All the issues mentioned in this pull request relate to the problem I'm trying to solve.
- [X] The code I'm sending follows the [PSR-12](https://www.php-fig.org/psr/psr-12/) coding style.
