### PR TITLE
Fix link style for boxed and centered layouts

### DIFF
--- a/src/assets/css/multiple-authors-widget.css
+++ b/src/assets/css/multiple-authors-widget.css
@@ -52,9 +52,14 @@
     margin: 10px 0 20px;
 }
 
+.pp-multiple-authors-layout-boxed .multiple-authors-name,
+.pp-multiple-authors-layout-centered .multiple-authors-name {
+    margin-bottom: 10px;
+}
+
 .pp-multiple-authors-layout-boxed .multiple-authors-name a,
 .pp-multiple-authors-layout-centered .multiple-authors-name a {
-    margin-bottom: 0;
+    margin-bottom: 10px;
     font-size: 1.2em;
 }
 

--- a/src/assets/css/multiple-authors-widget.css
+++ b/src/assets/css/multiple-authors-widget.css
@@ -55,13 +55,7 @@
 .pp-multiple-authors-layout-boxed .multiple-authors-name a,
 .pp-multiple-authors-layout-centered .multiple-authors-name a {
     margin-bottom: 0;
-}
-
-.pp-multiple-authors-layout-boxed a,
-.pp-multiple-authors-layout-centered a {
     font-size: 1.2em;
-    margin-bottom: 10px;
-    display: inline-block;
 }
 
 .pp-multiple-authors-layout-boxed .multiple-authors-links,
@@ -80,6 +74,7 @@
     margin-bottom: 0;
     margin-right: 1px;
     text-decoration: none;
+    display: inline-block;
 }
 
 .pp-multiple-authors-layout-boxed .multiple-authors-links a:hover,


### PR DESCRIPTION
## Description
If a link is added into the author description, the size is bigger.

## Current result: links in description are bigger than the plain text
<img width="888" alt="Screen Shot 2021-03-24 at 10 27 05" src="https://user-images.githubusercontent.com/4999794/112346545-aca88480-8c8b-11eb-8185-65ac45bb1b89.png">


## Expected result: links in description uses the same size as the plain text
<img width="892" alt="Screen Shot 2021-03-24 at 10 27 31" src="https://user-images.githubusercontent.com/4999794/112346558-b0d4a200-8c8b-11eb-86da-b124fec1f419.png">

