### PR TITLE
Handling issues when post author is zero

### DIFF
--- a/src/functions/template-tags.php
+++ b/src/functions/template-tags.php
@@ -128,7 +128,7 @@ if (!function_exists('get_multiple_authors')) {
                 $post = get_post($postId);
 
                 // TODO: Should we really just fail silently? Check WP_DEBUG and add a log error message.
-                if (empty($post) || is_wp_error($post)) {
+                if (empty($post) || is_wp_error($post) || empty($post->post_author) ) {
                     return [];
                 }
 


### PR DESCRIPTION
<!--
  Hey, that's awesome! Thanks for your interest and for taking the time to contribute.
  The following is a set of guidelines for contributing to PublishPress Authors plugin. Use your best judgment, and feel free to propose changes to this document in a pull request. 
  
  Filling out this template is required when contributing.
  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
  
  Please, review the guidelines for contributing to this repository:
  
  https://github.com/publishpress/PublishPress-Authors/blob/development/CONTRIBUTING.md
 -->

## Description
<!-- We must be able to understand the design of your change from this description. -->

When creating a new post via the PublishPress calendar view, using a custom post status that is configured to trigger a notification to an author, a 500 error is returned.

```bash
# Request, minus some headers.
curl --location --request POST 'https://localhost:31007/wp-admin/admin-ajax.php?action=publishpress_calendar_create_item' \
    --header 'Content-Type: application/x-www-form-urlencoded' \
    --data-urlencode 'post_type=post' \
    --data-urlencode 'date=2021-09-15' \
    --data-urlencode 'status=assigned' \
    --data-urlencode 'title=My awesome article' \
    --data-urlencode 'time=14:00' \
    --data-urlencode 'authors=-1356,-1164' \
    --data-urlencode 'categories=articles' \
    --data-urlencode 'tags=scg' \
    --data-urlencode 'content=<h1>My article!</h1>'
```

```html
<!-- Response -->
<p>There has been a critical error on this website.</p><p><a href="https://wordpress.org/support/article/faq-troubleshooting/">Learn more about troubleshooting WordPress.</a></p>
```

After some research, I've found that this endpoint is inserting the post with a negative author value. The `post_author` column of the `wp_posts` table has a datatype of a unsigned integer, and as such, the negative value is invalid, which causes the row's value to default value '0'.

As I understand things, creating a post triggers a number of workflows within publishpress.  I've found that the workflow for sending notifications attempts to send a notification to the post author before the authors can be set up properly on the post.

To save some time outlining each step here, here is a backtrace of the function calls to get to the issue at hand.

```php

    error_log(wp_debug_backtrace_summary());

    // Output
    /*
        do_action('wp_ajax_publishpress_calendar_create_item'), 
        WP_Hook->do_action, 
        WP_Hook->apply_filters, 
        PP_Calendar->createItem, 
        wp_insert_post, 
        wp_transition_post_status, 
        do_action('transition_post_status'), 
        WP_Hook->do_action, 
        WP_Hook->apply_filters, 
        PP_Improved_Notifications->action_transition_post_status, 
        do_action('publishpress_notifications_trigger_workflows'), 
        WP_Hook->do_action, 
        WP_Hook->apply_filters, 
        PublishPress\Notifications\Workflow\WorkflowsController->trigger_workflows, 
        PublishPress\Notifications\Workflow\Workflow->run, 
        do_action('publishpress_notifications_running_for_post'), 
        WP_Hook->do_action, 
        WP_Hook->apply_filters, 
        PublishPress\Notifications\Workflow\Step\Action\Notification->send_sync_notifications, 
        PublishPress\Notifications\Workflow\Step\Action\Notification->send_notifications, 
        PublishPress\Notifications\Workflow\Workflow->get_receivers_by_channel, 
        PublishPress\Notifications\Workflow\Workflow->get_receivers, 
        apply_filters('publishpress_notif_run_workflow_receivers'), 
        WP_Hook->apply_filters, 
        PublishPress\Notifications\Workflow\Step\Receiver\Author->filter_workflow_receivers, 
        apply_filters('publishpress_notifications_receiver_post_authors'), 
        WP_Hook->apply_filters, 
        MA_Multiple_Authors->filter_workflow_receiver_post_authors, 
        get_multiple_authors
    */
```

The proposed change here is to improve the `get_multiple_authors` function's ability to deal with the case where $posts->post_author is zero.


## Benefits
<!-- What benefits will be realized the code changes? -->

Fixing the issue.


## Possible drawbacks
<!-- What are the possible side-effects or negative impacts of the code changes? -->

More research would likely be warranted to determine if there are any side effects or drawbacks.

## Applicable issues
<!-- Link any applicable Issues here -->
I looked, didn't see any.


## Checklist

<!-- Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have created a specific branch for this pull request before committing, starting off the current HEAD of `development` branch. 
- [x] I'm submitting to the `development`, feature/hotfix/release branch. (Do not submit to the master branch!)
- [x] This pull request relates to a specific problem (bug or improvement).
- [ ] I have mentioned the issue number in the pull request description text.
- [x] All the issues mentioned in this pull request relate to the problem I'm trying to solve.
- [x] The code I'm sending follows the [PSR-12](https://www.php-fig.org/psr/psr-12/) coding style.