### PR TITLE
Use built-in capability check when searching users via ajax

### DIFF
--- a/src/core/Classes/Admin_Ajax.php
+++ b/src/core/Classes/Admin_Ajax.php
@@ -138,7 +138,8 @@ class Admin_Ajax
         // We load 100, but only display 20. We load more, because we are filtering users with "edit_posts" capability.
         // TODO: Add settings field for selecting what user role could be used to map users to authors, so we can filter the user role instead.
         $user_args = [
-            'number' => 100,
+            'number' => 20,
+            'capability' => 'edit_posts',
         ];
         if (!empty($_GET['q'])) {
             $user_args['search'] = sanitize_text_field('*' . $_GET['q'] . '*');
@@ -146,21 +147,11 @@ class Admin_Ajax
 
         $users   = get_users($user_args);
         $results = [];
-        $count   = 0;
         foreach ($users as $user) {
-            if ($count >= 20) {
-                break;
-            }
-
-            if (!user_can($user, 'edit_posts')) {
-                continue;
-            }
-
             $results[] = [
                 'id'   => $user->ID,
                 'text' => $user->display_name,
             ];
-            $count++;
         }
         $response = [
             'results' => $results,


### PR DESCRIPTION
## Description

We encountered a problem this week where the user search selectors were not returning any users upon initial interaction. 

Looking into the issue, it appears that we fell into a corner case, where none of the 100 users returned by the `get_users` method inside the `handle_users_search` AJAX handler method had the capability to `edit_posts`, and as such, the AJAX handler method returned an empty array as its results, making the user search selectors display as empty. Upon further testing, I discovered that if you searched for a particular user by partial keyword match, that the AJAX handler method was still able to return results, if an only if one or more of the 100 users it queried had the capability to `edit_posts`

I am guessing we are somewhat unique in our situation here, in that we run a subscription based content service, which results in us have a large user base. 

## Benefits
Adding the search constraints to the WP_Query object should be easier/faster than returning more results than required and brute-force filtering them.

## Possible drawbacks
None that I can foresee.

## Applicable issues
N/A

## Checklist

<!-- Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have created a specific branch for this pull request before committing, starting off the current HEAD of `development` branch. 
- [x] I'm submitting to the `development`, feature/hotfix/release branch. (Do not submit to the master branch!)
- [x] This pull request relates to a specific problem (bug or improvement).
- [x] I have mentioned the issue number in the pull request description text.
- [x] All the issues mentioned in this pull request relate to the problem I'm trying to solve.
- [x] The code I'm sending follows the [PSR-12](https://www.php-fig.org/psr/psr-12/) coding style.
