### PR TITLE
Remove CSS override for primary button

### DIFF
--- a/src/assets/css/pressshack-admin.css
+++ b/src/assets/css/pressshack-admin.css
@@ -151,25 +151,6 @@
     border-style: solid;
 }
 
-.pressshack-admin-wrapper .button-primary {
-    background-color: #FFB300;
-    border-color: #C58C07;
-    color: #754D26;
-}
-
-.pressshack-admin-wrapper .button-primary:hover,
-.pressshack-admin-wrapper .button-primary:active,
-.pressshack-admin-wrapper .button-primary:focus {
-    background-color: #F3AC04;
-    border-color: #C58C07;
-    color: #333;
-    outline: none;
-    box-shadow: 0 1px 0 rgba(255, 255, 255, 0.2) inset, 0 1px 2px rgba(0, 0, 0, 0.05);
-    -moz-box-shadow: 0 1px 0 rgba(255, 255, 255, 0.2) inset, 0 1px 2px rgba(0, 0, 0, 0.05);
-    -webkit-box-shadow: 0 1px 0 rgba(255, 255, 255, 0.2) inset, 0 1px 2px rgba(0, 0, 0, 0.05);
-    -o-box-shadow: 0 1px 0 rgba(255, 255, 255, 0.2) inset, 0 1px 2px rgba(0, 0, 0, 0.05);
-}
-
 .pressshack-admin-wrapper .button:not(.notice-dismiss):hover,
 .pressshack-admin-wrapper .button:not(.notice-dismiss):active,
 .pressshack-admin-wrapper .button:not(.notice-dismiss):focus {


### PR DESCRIPTION
The buttons with `button-primary` class are overridden with yellow style. This PR removes this result.
Only the most important buttons should be yellow. e.g. "Upgrade to Pro"

#704
