### PR TITLE
feature/#818_Conflict_with_PublishPress_Calendar 

### DIFF
--- a/src/functions/template-tags.php
+++ b/src/functions/template-tags.php
@@ -53,10 +53,11 @@ if (!function_exists('get_post_authors')) {
      *                                            in quick edit after saving.
      *                                            That's why in Post_Editor we called this function with overriding
      *                                            ignoreCache value to be equal true.
+     * @param bool $updateAuthors Updating authors early causes issue with some plugins that get post earlier
      *
      * @return array Array of Author objects, a single WP_User object, or empty.
      */
-    function get_post_authors($post = 0, $ignoreCache = false)
+    function get_post_authors($post = 0, $ignoreCache = false, $updateAuthors = true)
     {
         if (is_object($post)) {
             $post = $post->ID;
@@ -141,7 +142,7 @@ if (!function_exists('get_post_authors')) {
                 $authorsInstances = [$author];
             }
 
-            if (!empty($authorsInstances)) {
+            if (!empty($authorsInstances) && $updateAuthors) {
                 Utils::set_post_authors($postId, $authorsInstances);
             }
         }
@@ -447,7 +448,8 @@ if (!function_exists('is_multiple_author_for_post')) {
         }
 
         if (!isset($postAuthorsCache[$post_id])) {
-            $coauthors = get_post_authors($post_id);
+
+            $coauthors = get_post_authors($post_id, false, false);
 
             $postAuthorsCache[$post_id] = $coauthors;
         }


### PR DESCRIPTION
<!--
  Hey, that's awesome! Thanks for your interest and for taking the time to contribute.
  The following is a set of guidelines for contributing to PublishPress Authors plugin. Use your best judgment, and feel free to propose changes to this document in a pull request. 
  
  Filling out this template is required when contributing.
  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
  
  Please, review the guidelines for contributing to this repository:
  
  https://github.com/publishpress/PublishPress-Authors/blob/development/CONTRIBUTING.md
 -->

## Description
<!-- We must be able to understand the design of your change from this description. -->
- Conflict with PublishPress Calendar #818

## Benefits
<!-- What benefits will be realized the code changes? -->

## Possible drawbacks
<!-- What are the possible side-effects or negative impacts of the code changes? -->

## Applicable issues
<!-- Link any applicable Issues here -->
https://github.com/publishpress/PublishPress-Authors/issues/818

## Checklist

<!-- Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have created a specific branch for this pull request before committing, starting off the current HEAD of `development` branch. 
- [x] I'm submitting to the `development`, feature/hotfix/release branch. (Do not submit to the master branch!)
- [x] This pull request relates to a specific problem (bug or improvement).
- [x] I have mentioned the issue number in the pull request description text.
- [x] All the issues mentioned in this pull request relate to the problem I'm trying to solve.
- [x] The code I'm sending follows the [PSR-12](https://www.php-fig.org/psr/psr-12/) coding style.
