### PR TITLE
#999 - Pass the post id if it's been set

### DIFF
--- a/src/core/Traits/Author_box.php
+++ b/src/core/Traits/Author_box.php
@@ -229,7 +229,7 @@ trait Author_box
          */
         $html = apply_filters('pp_multiple_authors_author_box_html', null, $args);
 
-        $authors_iterator = new Authors_Iterator(0, $archive);
+        $authors_iterator = new Authors_Iterator($post_id ?? 0, $archive);
 
         /**
          * Filter the rendered markup of the author box.


### PR DESCRIPTION
## Description
Possible fix to issue #999 

## Benefits
No notices thrown into templates

## Possible drawbacks
I don't know enough about the codebase to know if there was a specific reason for throwing away the post_id in this instance. The replaced line of code seems to have been in place for 3 years, so it must have been doing something right.

## Applicable issues
<!-- Link any applicable Issues here -->

## Checklist

- [ ] I have created a specific branch for this pull request before committing, starting off the current HEAD of `development` branch. 
- [x] I'm submitting to the `development`, feature/hotfix/release branch. (Do not submit to the master branch!)
- [x] This pull request relates to a specific problem (bug or improvement).
- [x] I have mentioned the issue number in the pull request description text.
- [x] All the issues mentioned in this pull request relate to the problem I'm trying to solve.
- [x] The code I'm sending follows the [PSR-12](https://www.php-fig.org/psr/psr-12/) coding style.
