### PR TITLE
feature/#1780_Fix_PublishPress_Authors_View_is_not_readable_inline_error_when_using_legacy_layout_in_shortcode

### DIFF
--- a/src/modules/author-boxes/author-boxes.php
+++ b/src/modules/author-boxes/author-boxes.php
@@ -788,7 +788,12 @@ class MA_Author_Boxes extends Module
             $legacyPlugin              = Factory::getLegacyPlugin();
             $legacy_layout_author_box   = $legacyPlugin->modules->multiple_authors->options->{'author_legacy_layout_' . $layoutName};
             if (empty($legacy_layout_author_box)) {
-                return $html; 
+                // set the legacy layout setting
+                $author_box_id = $this->getLegacyLayoutAuthorBoxId($layoutName);
+                $legacyPlugin->update_module_option('multiple_authors', 'author_legacy_layout_' . $layoutName, self::POST_TYPE_BOXES . '_' . $author_box_id);
+                if ($author_box_id === 0) {
+                    return $html;
+                }
             }
             $author_box_id = (int) preg_replace("/[^0-9]/", "", $legacy_layout_author_box );
             if ($author_box_id === 0) {


### PR DESCRIPTION
Fix "PublishPress Authors: View is not readable: inline" error when using legacy layout in shortcode fix #1780