### PR TITLE
Update author-boxes.php

### DIFF
--- a/src/modules/author-boxes/author-boxes.php
+++ b/src/modules/author-boxes/author-boxes.php
@@ -1891,7 +1891,10 @@ class MA_Author_Boxes extends Module
                 </div>
             </nav>
         <?php endif; ?>
-        <?php Utils::loadLayoutFrontCss(); ?>
+        
+        <?php if (apply_filters('publishpress_authors_load_style_in_frontend', PUBLISHPRESS_AUTHORS_LOAD_STYLE_IN_FRONTEND)) :
+            Utils::loadLayoutFrontCss();
+        endif; ?>
 
         <?php if ($admin_preview || is_admin()) : ?>
             <div class="pp-author-boxes-editor-preview-styles">


### PR DESCRIPTION
## Description

Even I use `publishpress_authors_load_style_in_frontend` to define load logic to false, I still have css loaded, found the place where condition was missed.

## Benefits
Not load front css when it is not needed.

## Possible drawbacks
Maybe it can cause issues for users that used loaded css event `publishpress_authors_load_style_in_frontend` set to `false` on their side.

## Checklist

- [x] I have created a specific branch for this pull request before committing, starting off the current HEAD of `development` branch. 
- [x] I'm submitting to the `development`, feature/hotfix/release branch. (Do not submit to the master branch!)
- [ ] This pull request relates to a specific problem (bug or improvement).
- [ ] I have mentioned the issue number in the pull request description text.
- [ ] All the issues mentioned in this pull request relate to the problem I'm trying to solve.
- [x] The code I'm sending follows the [PSR-12](https://www.php-fig.org/psr/psr-12/) coding style.
