### PR TITLE
 fix/#1878-Author-category-filter-returning-all-Authors-when-none-is-found 

### DIFF
--- a/src/core/Traits/Author_box.php
+++ b/src/core/Traits/Author_box.php
@@ -177,6 +177,10 @@ trait Author_box
             }
         }
 
+        if (empty($authorsList)) {
+            return '';
+        }
+
         $this->authorsCount = count($authorsList);
 
         if ($this->authorsCount === 1) {


### PR DESCRIPTION
Author category filter returning all Authors when none is found fix #1878