### PR TITLE
Prevented mid-word cuts for readability

### DIFF
--- a/src/core/Classes/Utils.php
+++ b/src/core/Classes/Utils.php
@@ -946,10 +946,8 @@ class Utils
         $excerpt = strip_shortcodes($excerpt);
         $excerpt = wp_strip_all_tags($excerpt);
 
-        if (strlen($excerpt) > $limit) {
-            // truncate excerpt
-            $excerpt = substr($excerpt, 0, $limit);
-        }
+        // If the string length exceeds $limit, we look for the nearest space
+        $excerpt = strlen($excerpt) > $limit ? substr($excerpt, 0, strpos($excerpt . ' ', ' ', $limit)) : $excerpt;
 
         if (!empty($author_post_excerpt_ellipsis) && !empty(trim($excerpt))) {
             $excerpt .= $author_post_excerpt_ellipsis;


### PR DESCRIPTION
## Description
Prevented cutting words in the middle when limiting the text length. Instead of a hard character limit, the string is now truncated at the first space after reaching the limit, ensuring a more natural text display.

## Benefits
Doesn't cut off SHORTCODE for example

## Possible drawbacks
Perhaps there is no space in the string, so it will show it in full and not with the hardcoded 160 limit

## Applicable issues
<!-- Link any applicable Issues here -->

## Checklist

<!-- Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have created a specific branch for this pull request before committing, starting off the current HEAD of `development` branch. 
- [x] I'm submitting to the `development`, feature/hotfix/release branch. (Do not submit to the master branch!)
- [x] This pull request relates to a specific problem (bug or improvement).
- [x] I have mentioned the issue number in the pull request description text.
- [x] All the issues mentioned in this pull request relate to the problem I'm trying to solve.
- [x] The code I'm sending follows the [PSR-12](https://www.php-fig.org/psr/psr-12/) coding style.
