### PR TITLE
fix/#2007-Missing-field-mainEntity-in-rankmath-integration

### DIFF
--- a/src/modules/rank-math-seo-integration/rank-math-seo-integration.php
+++ b/src/modules/rank-math-seo-integration/rank-math-seo-integration.php
@@ -144,7 +144,16 @@ if (!class_exists('MA_Rank_Math_Seo_Integration')) {
 
                     $data['WebPage']['@type']  = 'ProfilePage';
                     $data['ProfilePage']        = $author_profile_data;
+
+                    $mainEntityOfPage = $page_author->link;
+                    if (isset($data['WebPage']['@id'])) {
+                        $mainEntityOfPage = $data['WebPage']['@id'];
+                    }
+                    $data['ProfilePage']['mainEntityOfPage'] = [
+                        '@id' => $mainEntityOfPage
+                    ];
                 }
+
             }
 
             return $data;


### PR DESCRIPTION
Missing field "mainEntity" in rankmath integration fix #2007
Missing field “mainEntity” fix #1782
