### PR TITLE
PHP Fatal error: Uncaught TypeError: array_search(): Argument #2 ($haystack) must be of type array, null given

### DIFF
--- a/src/core/Classes/Utils.php
+++ b/src/core/Classes/Utils.php
@@ -632,6 +632,10 @@ class Utils
         $taxonomy = get_taxonomy('author');
         $postTypes = $taxonomy->object_type;
 
+        if (!$postTypes || !is_array($postTypes)) {
+            return [];
+        }
+
         if (($keyToUnset = array_search('customize_changeset', $postTypes)) !== false) {
             unset($postTypes[$keyToUnset]);
         }

--- a/src/core/Plugin.php
+++ b/src/core/Plugin.php
@@ -1137,7 +1137,11 @@ class Plugin
     {
         global $wpdb;
 
-        $post_types = array_values(Utils::getAuthorTaxonomyPostTypes());
+        $post_types = array_values(Utils::get_enabled_post_types());
+
+        if (empty($post_types)) {
+            $post_types = ['post'];
+        }
 
         $post_types = array_map('esc_sql', $post_types);
         $post_types_in = "'" . implode("','", $post_types) . "'";


### PR DESCRIPTION
PHP Fatal error: Uncaught TypeError: array_search(): Argument #2 ($haystack) must be of type array, null given fix #2081
