### PR TITLE
Author profile rich editor field Line breaks not reflecting in the frontend

### DIFF
--- a/src/modules/author-boxes/author-boxes.php
+++ b/src/modules/author-boxes/author-boxes.php
@@ -1715,7 +1715,7 @@ class MA_Author_Boxes extends Module
                                                                 }
 
                                                                 if ($data['type'] === 'wysiwyg') {
-                                                                    $field_value = $author->$key;
+                                                                    $field_value = wpautop($author->$key);
                                                                 } else {
                                                                     $field_value = esc_html($author->$key);
                                                                 }
@@ -1928,7 +1928,7 @@ class MA_Author_Boxes extends Module
                                                                         <?php if ($args['author_bio_link']['value']) : ?>
                                                                             <a href="<?php echo esc_url($author->link); ?>" title="<?php echo esc_attr__('Author', 'publishpress-authors'); ?>">
                                                                         <?php endif; ?>
-                                                                            <?php echo $author->get_description($args['author_bio_limit']['value']);  // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                                                                            <?php echo wpautop($author->get_description($args['author_bio_limit']['value']));  // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
                                                                         <?php if ($args['author_bio_link']['value']) : ?>
                                                                             </a>
                                                                         <?php endif; ?>

--- a/src/modules/author-boxes/classes/AuthorBoxesAjax.php
+++ b/src/modules/author-boxes/classes/AuthorBoxesAjax.php
@@ -571,7 +571,7 @@ endif ?>
 <?php if ($args['author_bio_show']['value']) : ?>
                             <<?php echo esc_html($args['author_bio_html_tag']['value']); ?> class="pp-author-boxes-description multiple-authors-description author-description-</?php echo esc_attr($index); ?>">
 <?php if ($args['author_bio_link']['value']) : ?><a href="</?php echo esc_url($author->link); ?>" title="</?php echo esc_attr__('Author', 'publishpress-authors'); ?>"><?php endif; ?>
-                                </?php echo $author->get_description(<?php echo esc_html($args['author_bio_limit']['value']); ?>); ?>
+                                </?php echo wpautop($author->get_description(<?php echo esc_html($args['author_bio_limit']['value']); ?>)); ?>
 <?php if ($args['author_bio_link']['value']) : ?></a><?php endif; ?>
                             </<?php echo esc_html($args['author_bio_html_tag']['value']); ?>>
 <?php endif; ?>


### PR DESCRIPTION

Author profile rich editor field Line breaks not reflecting in the frontend fix #2132