### PR TITLE
Introduced filter to prevent rewrite rules flush on user updates

### DIFF
--- a/src/modules/multiple-authors/multiple-authors.php
+++ b/src/modules/multiple-authors/multiple-authors.php
@@ -4775,7 +4775,17 @@ echo '<span class="ppma_settings_field_description">'
 
                 $wpdb->update($wpdb->terms, ['slug' => $user->user_nicename], ['term_id' => $author->term_id]);
 
-                if (is_object($wp_rewrite)) {
+                /**
+                 * Filter whether to flush rewrite rules on user profile update.
+                 *
+                 * @param bool $should_flush Whether to flush rewrite rules. Default true.
+                 * @param int $userId The ID of the user being updated.
+                 * @param WP_User $oldUserData The old user data.
+                 * @param object $author The author object.
+                 */
+                $should_flush = apply_filters( 'pp_authors_should_flush_rewrite_rules_on_user_profile_update', true, $userId, $oldUserData, $author );
+
+                if ($should_flush && is_object($wp_rewrite)) {
                     $wp_rewrite->flush_rules(); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.flush_rules_flush_rules
                 }
             }


### PR DESCRIPTION
## Description
This pull request introduces a filter to control whether rewrite rules should be flushed when a user profile is updated.
Added the `pp_authors_should_flush_rewrite_rules_on_user_profile_update` filter to allow developers to control whether rewrite rules are flushed on user profile update in the `userProfileUpdate` function (`multiple-authors.php`).

## Benefits
This change increases flexibility for developers by allowing them to override the default behavior.

## Possible drawbacks
None

## Applicable issues
N/A

## Checklist

- [X] I have created a specific branch for this pull request before committing, starting off the current HEAD of `development` branch. 
- [X] I'm submitting to the `development`, feature/hotfix/release branch. (Do not submit to the master branch!)
- [X] This pull request relates to a specific problem (bug or improvement).
- [ ] I have mentioned the issue number in the pull request description text.
- [X] All the issues mentioned in this pull request relate to the problem I'm trying to solve.
- [X] The code I'm sending follows the [PSR-12](https://www.php-fig.org/psr/psr-12/) coding style.
