### PR TITLE
fix/#2189-Replace-esc_attr_e-and-esc_html_e-with-proper-escaping-functions-for-non-translatable-strings

### DIFF
--- a/src/core/Classes/Author_Editor.php
+++ b/src/core/Classes/Author_Editor.php
@@ -258,11 +258,11 @@ class Author_Editor
         foreach ($fields_tabs as $key => $args) {
             $active_tab = ($key === self::AUTHOR_EDITOR_DEFAULT_TAB) ? ' nav-tab-active' : '';
         ?>
-        <a data-tab="<?php esc_attr_e($key); ?>"
-            class="<?php esc_attr_e('tab-link nav-tab' . $active_tab ); ?>"
+        <a data-tab="<?php echo esc_attr($key); ?>"
+            class="<?php echo esc_attr('tab-link nav-tab' . $active_tab ); ?>"
             href="#"
             >
-            <?php esc_html_e($args['label']); ?>
+            <?php echo esc_html($args['label']); ?>
         </a>
         <?php
         }

--- a/src/modules/author-boxes/author-boxes.php
+++ b/src/modules/author-boxes/author-boxes.php
@@ -1450,12 +1450,12 @@ class MA_Author_Boxes extends Module
                     foreach ($fields_tabs as $key => $args) {
                         $active_tab = ($key === self::default_tab()) ? ' active' : ''; ?>
                     <li>
-                        <a data-tab="<?php esc_attr_e($key); ?>"
-                            class="<?php esc_attr_e($active_tab); ?>"
+                        <a data-tab="<?php echo esc_attr($key); ?>"
+                            class="<?php echo esc_attr($active_tab); ?>"
                             href="#"
                             >
-                            <span class="<?php esc_attr_e($args['icon']); ?>"></span>
-                            <span class="item"><?php esc_html_e($args['label']); ?></span>
+                            <span class="<?php echo esc_attr($args['icon']); ?>"></span>
+                            <span class="item"><?php echo esc_html($args['label']); ?></span>
                         </a>
                     </li>
                     <?php

--- a/src/views/authors-list-widget-form.html.php
+++ b/src/views/authors-list-widget-form.html.php
@@ -1,62 +1,62 @@
 <p>
-    <label for="<?php echo esc_attr($context['ids']['title']); ?>"><?php esc_html_e($context['labels']['title']); ?></label>
+    <label for="<?php echo esc_attr($context['ids']['title']); ?>"><?php echo esc_html($context['labels']['title']); ?></label>
     <input class="widefat" id="<?php echo esc_attr($context['ids']['title']); ?>" name="<?php echo esc_attr($context['names']['title']); ?>" type="text"
            value="<?php echo esc_attr($context['values']['title']); ?>">
 </p>
 <p>
-    <label for="<?php echo esc_attr($context['ids']['layout']); ?>"><?php esc_html_e($context['labels']['layout']); ?></label>
+    <label for="<?php echo esc_attr($context['ids']['layout']); ?>"><?php echo esc_html($context['labels']['layout']); ?></label>
 
     <select id="<?php echo esc_attr($context['ids']['layout']); ?>" name="<?php echo esc_attr($context['names']['layout']); ?>">
         <?php foreach ($context['layouts'] as $layout => $label) : ?>
             <option value="<?php echo esc_attr($layout); ?>"
                 <?php selected($layout, $context['values']['layout']); ?>
-            ><?php esc_html_e($label); ?></option>
+            ><?php echo esc_html($label); ?></option>
         <?php endforeach; ?>
     </select>
 </p>
 <p>
-    <label for="<?php echo esc_attr($context['ids']['authors']); ?>"><?php esc_html_e($context['labels']['authors']); ?></label>
+    <label for="<?php echo esc_attr($context['ids']['authors']); ?>"><?php echo esc_html($context['labels']['authors']); ?></label>
 
     <select id="<?php echo esc_attr($context['ids']['authors']); ?>" name="<?php echo esc_attr($context['names']['authors']); ?>">
         <?php foreach ($context['options']['authors'] as $key => $label) : ?>
             <option value="<?php echo esc_attr($key); ?>"
                 <?php selected($key, $context['values']['authors']); ?>
-            ><?php esc_html_e($label); ?></option>
+            ><?php echo esc_html($label); ?></option>
         <?php endforeach; ?>
 
     </select>
 </p>
 
 <p>
-    <label for="<?php echo esc_attr($context['ids']['orderby']); ?>"><?php esc_html_e($context['labels']['orderby']); ?></label>
+    <label for="<?php echo esc_attr($context['ids']['orderby']); ?>"><?php echo esc_html($context['labels']['orderby']); ?></label>
 
     <select id="<?php echo esc_attr($context['ids']['orderby']); ?>" name="<?php echo esc_attr($context['names']['orderby']); ?>">
 
         <?php foreach ($context['options']['orderby'] as $key => $label) : ?>
             <option value="<?php echo esc_attr($key); ?>"
                 <?php selected($key, $context['values']['orderby']); ?>
-            ><?php esc_html_e($label); ?></option>
+            ><?php echo esc_html($label); ?></option>
         <?php endforeach; ?>
 
     </select>
 </p>
 
 <p>
-    <label for="<?php echo esc_attr($context['ids']['order']); ?>"><?php esc_html_e($context['labels']['order']); ?></label>
+    <label for="<?php echo esc_attr($context['ids']['order']); ?>"><?php echo esc_html($context['labels']['order']); ?></label>
 
     <select id="<?php echo esc_attr($context['ids']['order']); ?>" name="<?php echo esc_attr($context['names']['order']); ?>">
 
         <?php foreach ($context['options']['order'] as $key => $label) : ?>
             <option value="<?php echo esc_attr($key); ?>"
                 <?php selected($key, $context['values']['order']); ?>
-            ><?php esc_html_e($label); ?></option>
+            ><?php echo esc_html($label); ?></option>
         <?php endforeach; ?>
 
     </select>
 </p>
 
 <p>
-    <label for="<?php echo esc_attr($context['ids']['limit_per_page']); ?>"><?php esc_html_e($context['labels']['limit_per_page']); ?></label>
+    <label for="<?php echo esc_attr($context['ids']['limit_per_page']); ?>"><?php echo esc_html($context['labels']['limit_per_page']); ?></label>
     <input class="widefat" id="<?php echo esc_attr($context['ids']['limit_per_page']); ?>" name="<?php echo esc_attr($context['names']['limit_per_page']); ?>" type="number"
            value="<?php echo esc_attr($context['values']['limit_per_page']); ?>">
 </p>
@@ -65,7 +65,7 @@
     <input class="checkbox" id="<?php echo esc_attr($context['ids']['show_empty']); ?>" name="<?php echo esc_attr($context['names']['show_empty']); ?>" type="checkbox"
     <?php checked($context['values']['show_empty'], true); ?>
     />
-    <label for="<?php echo esc_attr($context['ids']['show_empty']); ?>"><?php esc_html_e($context['labels']['show_empty']); ?></label>
+    <label for="<?php echo esc_attr($context['ids']['show_empty']); ?>"><?php echo esc_html($context['labels']['show_empty']); ?></label>
 </p>
 
 <p>

--- a/src/views/authors_index.html.php
+++ b/src/views/authors_index.html.php
@@ -1,14 +1,14 @@
-<div class="pp-multiple-authors-wrapper pp-multiple-authors-index alignwide <?php esc_attr_e($context['css_class']); ?> pp-multiple-authors-layout-<?php esc_attr_e($context['layout']); ?>">
+<div class="pp-multiple-authors-wrapper pp-multiple-authors-index alignwide <?php echo esc_attr($context['css_class']); ?> pp-multiple-authors-layout-<?php echo esc_attr($context['layout']); ?>">
     <?php if (!empty($context['search_box_html'])) : ?>
         <?php echo $context['search_box_html']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
     <?php endif; ?>
     <ul class="author-index-navigation">
-        <li class="page-item active" data-item="all"><a class="page-link " href="#"><?php esc_html_e($context['all_text']); ?></a></li>
+        <li class="page-item active" data-item="all"><a class="page-link " href="#"><?php echo esc_html($context['all_text']); ?></a></li>
         <?php foreach ($context['results'] as $key => $value) :
             $display_title = publishpress_authors_get_index_display_title($key);
         ?>
-            <li class="page-item" data-item="<?php esc_attr_e($key); ?>">
-                <a class="page-link" href="#"><?php esc_html_e(strtoupper($display_title)); ?></a>
+            <li class="page-item" data-item="<?php echo esc_attr($key); ?>">
+                <a class="page-link" href="#"><?php echo esc_html(strtoupper($display_title)); ?></a>
             </li>
         <?php endforeach; ?>
     </ul>
@@ -16,19 +16,19 @@
     $currentUserIndex = 0;
     foreach ($context['results'] as $alphabet => $users) :
         $display_title = publishpress_authors_get_index_display_title($alphabet); ?>
-        <div class="author-index-group author-index-group-<?php esc_attr_e($alphabet); ?>">
+        <div class="author-index-group author-index-group-<?php echo esc_attr($alphabet); ?>">
             <div class="author-index-header">
-                <h4 class="author-list-head author-list-head-<?php esc_attr_e($alphabet); ?>"><?php esc_html_e(strtoupper($display_title)); ?></h4>
+                <h4 class="author-list-head author-list-head-<?php echo esc_attr($alphabet); ?>"><?php echo esc_html(strtoupper($display_title)); ?></h4>
             </div>
-            <div class="author-index-authors author-index-<?php esc_attr_e($alphabet); ?>">
+            <div class="author-index-authors author-index-<?php echo esc_attr($alphabet); ?>">
                 <ul>
                     <?php foreach ($users as $author) :
                         $currentUserIndex = $currentUserIndex + 1;
                         ?>
-                        <li class="author-index-item author_index_<?php esc_attr_e($currentUserIndex); ?> author_<?php esc_attr_e($author->slug); ?>">
+                        <li class="author-index-item author_index_<?php echo esc_attr($currentUserIndex); ?> author_<?php echo esc_attr($author->slug); ?>">
                             <div class="tease-author">
                                 <div class="author-index-author-name">
-                                    <a href="<?php echo esc_url($author->link); ?>" class="<?php esc_attr_e($context['item_class']); ?>" rel="author" title="<?php esc_attr_e($author->display_name); ?>">
+                                    <a href="<?php echo esc_url($author->link); ?>" class="<?php echo esc_attr($context['item_class']); ?>" rel="author" title="<?php echo esc_attr($author->display_name); ?>">
                                         <?php echo $author->display_name; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
                                     </a>
                                 </div>

--- a/src/views/authors_recent.html.php
+++ b/src/views/authors_recent.html.php
@@ -1,4 +1,4 @@
-<div class="pp-multiple-authors-wrapper pp-multiple-authors-recent alignwide <?php esc_attr_e($context['css_class']); ?> pp-multiple-authors-layout-<?php esc_attr_e($context['layout']); ?>">
+<div class="pp-multiple-authors-wrapper pp-multiple-authors-recent alignwide <?php echo esc_attr($context['css_class']); ?> pp-multiple-authors-layout-<?php echo esc_attr($context['layout']); ?>">
     <?php if (!empty($context['search_box_html'])) : ?>
         <?php echo $context['search_box_html']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
     <?php endif; ?>
@@ -6,11 +6,11 @@
         <?php foreach ($context['results'] as $index => $result) :
             $author = $result['author'];
             ?>
-            <div class="author_index_<?php esc_attr_e($index); ?> author_<?php esc_attr_e($author->slug); ?> ppma-author-entry ppma-col-md-3 ppma-col-sm-4 ppma-col-12">
-                <div class="name-row"><a href="<?php echo esc_url($author->link); ?>" class="<?php esc_attr_e($context['item_class']); ?>" rel="author" title="<?php esc_attr_e($author->display_name); ?>">
+            <div class="author_index_<?php echo esc_attr($index); ?> author_<?php echo esc_attr($author->slug); ?> ppma-author-entry ppma-col-md-3 ppma-col-sm-4 ppma-col-12">
+                <div class="name-row"><a href="<?php echo esc_url($author->link); ?>" class="<?php echo esc_attr($context['item_class']); ?>" rel="author" title="<?php echo esc_attr($author->display_name); ?>">
                     <h4><?php echo $author->display_name; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></h4>
                     </a>
-                    <a href="<?php echo esc_url($author->link); ?>" title="<?php esc_attr_e($author->display_name); ?>">
+                    <a href="<?php echo esc_url($author->link); ?>" title="<?php echo esc_attr($author->display_name); ?>">
                     <?php if ($author->get_avatar()) : ?>
                         <?php echo $author->get_avatar(107);  // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
                     <?php else : ?>
@@ -23,26 +23,26 @@
                         <?php if ($result['recent_posts']) : ?>
                             <?php foreach ($result['recent_posts'] as $post_id => $post) : ?>
                                 <?php if ($post['featuired_image']) : ?>
-                                    <div class="ppma-col-5 featured-image-col post-<?php esc_attr_e($post_id); ?>">
+                                    <div class="ppma-col-5 featured-image-col post-<?php echo esc_attr($post_id); ?>">
                                         <a href="<?php echo esc_url($post['permalink']); ?>">
                                             <img src="<?php echo esc_url($post['featuired_image']); ?>">
                                         </a>
                                     </div>
 
-                                    <div class="ppma-col-5 post-<?php esc_attr_e($post_id); ?>">
+                                    <div class="ppma-col-5 post-<?php echo esc_attr($post_id); ?>">
                                         <div class="text">
                                             <a href="<?php echo esc_url($post['permalink']); ?>" class="headline">
-                                                <?php esc_html_e($post['post_title']); ?>
+                                                <?php echo esc_html($post['post_title']); ?>
                                             </a>
                                         </div>
                                     </div>
                                 <?php else : ?>
-                                    <div class="ppma-col-12 post-column post-<?php esc_attr_e($post_id); ?>">
+                                    <div class="ppma-col-12 post-column post-<?php echo esc_attr($post_id); ?>">
                                         <div class="ppma-row-article-block secondary">
                                             <div class="ppma-col-12">
                                                 <div class="text">
                                                     <a href="<?php echo esc_url($post['permalink']); ?>" class="headline">
-                                                        <?php esc_html_e($post['post_title']); ?>
+                                                        <?php echo esc_html($post['post_title']); ?>
                                                     </a>
                                                 </div>
                                             </div>

--- a/src/views/widget-form.html.php
+++ b/src/views/widget-form.html.php
@@ -1,21 +1,21 @@
 <p>
-    <label for="<?php echo esc_attr($context['ids']['title']); ?>"><?php esc_html_e($context['labels']['title']); ?></label>
+    <label for="<?php echo esc_attr($context['ids']['title']); ?>"><?php echo esc_html($context['labels']['title']); ?></label>
     <input class="widefat" id="<?php echo esc_attr($context['ids']['title']); ?>" name="<?php echo esc_attr($context['names']['title']); ?>" type="text"
            value="<?php echo esc_attr($context['values']['title']); ?>">
 
-    <label for="<?php echo esc_attr($context['ids']['title_plural']); ?>"><?php esc_html_e($context['labels']['title_plural']); ?></label>
+    <label for="<?php echo esc_attr($context['ids']['title_plural']); ?>"><?php echo esc_html($context['labels']['title_plural']); ?></label>
     <input class="widefat" id="<?php echo esc_attr($context['ids']['title_plural']); ?>" name="<?php echo esc_attr($context['names']['title_plural']); ?>" type="text" value="<?php echo esc_attr($context['values']['title_plural']); ?>">
 
 </p>
 
 <p>
-    <label for="<?php echo esc_attr($context['ids']['layout']); ?>"><?php esc_html_e($context['labels']['layout']); ?></label>
+    <label for="<?php echo esc_attr($context['ids']['layout']); ?>"><?php echo esc_html($context['labels']['layout']); ?></label>
 
     <select id="<?php echo esc_attr($context['ids']['layout']); ?>" name="<?php echo esc_attr($context['names']['layout']); ?>">
         <?php foreach ($context['layouts'] as $layout => $label) : ?>
             <option value="<?php echo esc_attr($layout); ?>"
                 <?php selected($layout, $context['values']['layout']); ?>
-            ><?php esc_html_e($label); ?></option>
+            ><?php echo esc_html($label); ?></option>
         <?php endforeach; ?>
     </select>
 </p>


### PR DESCRIPTION
Replace esc_attr_e and esc_html_e with proper escaping functions for non-translatable strings fix #2189