### PR TITLE
fix/hide-author-user-email-from-rest-api-by-default

### DIFF
--- a/src/core/Classes/Author_Editor.php
+++ b/src/core/Classes/Author_Editor.php
@@ -378,6 +378,7 @@ class Author_Editor
                 'label'       => esc_html__('Email', 'publishpress-authors'),
                 'type'        => 'email',
                 'tab'         => 'general',
+                'show_in_rest' => 'off',
             ],
             'avatar'      => [
                 'label'       => __('Avatar Source', 'publishpress-authors'),

--- a/src/modules/rest-api/rest-api.php
+++ b/src/modules/rest-api/rest-api.php
@@ -588,7 +588,7 @@ if (!class_exists('MA_REST_API')) {
                 }
 
                 $field_config = $available_fields[$field_name];
-                if (isset($field_config['show_in_rest']) && $field_config['show_in_rest'] === 'off') {
+                if (!$this->isAuthorFieldVisibleInRest($field_name, $field_config)) {
                     continue;
                 }
 
@@ -596,6 +596,20 @@ if (!class_exists('MA_REST_API')) {
             }
 
             return new WP_REST_Response($response_data, $status_code);
+        }
+
+        private function isAuthorFieldVisibleInRest($field_name, $field_config)
+        {
+            if (is_array($field_config) && !empty($field_config['show_in_rest'])) {
+                return $field_config['show_in_rest'] !== 'off';
+            }
+
+            return !in_array($field_name, $this->getDefaultHiddenRestFields(), true);
+        }
+
+        private function getDefaultHiddenRestFields()
+        {
+            return apply_filters('ppma_rest_api_default_hidden_author_fields', ['user_email']);
         }
 
         private function sanitizeFieldValue($value, $field_config)


### PR DESCRIPTION
 Hide user_email from rest API by default