### PR TITLE
fix/Missing-output-escaping-in-admin-author-taxonomy-column-(defence-in-depth)

### DIFF
--- a/src/core/Classes/Term_Editor.php
+++ b/src/core/Classes/Term_Editor.php
@@ -61,8 +61,8 @@ class Term_Editor
 
             $content = sprintf(
                 '<a href="%s" target="_blank">%s</a>',
-                $author->link,
-                urldecode($author->slug)
+                esc_url($author->link),
+                esc_html(urldecode($author->slug))
             );
         }
 


### PR DESCRIPTION
Missing output escaping in admin author taxonomy column (defence-in-depth)