### PR TITLE
Fix: block-level HTML stripped from mapped-user Biographical Info on save

### DIFF
--- a/src/core/Classes/Author_Editor.php
+++ b/src/core/Classes/Author_Editor.php
@@ -696,7 +696,13 @@ class Author_Editor
             update_term_meta($term_id, $key, $field_value);
             if ($user_id) {
                 update_user_meta($user_id, $key, $field_value);
-                $updated_args[$key] = $field_value;
+                // Don't route the bio through wp_update_user(): core's
+                // pre_user_description filter (wp_filter_kses) strips block-level
+                // HTML (<p>, headings, lists) that wp_kses_post above allows. The
+                // update_user_meta() call just above already stored the correct value.
+                if ($key !== 'description') {
+                    $updated_args[$key] = $field_value;
+                }
             }
 
             if (in_array($args['type'], ['text', 'textarea'])) {


### PR DESCRIPTION
## Problem

Saving block-level HTML (`<p>`, headings, lists) into an author's **Biographical Info** field does not survive a save when the author is **mapped to a real WP user**. Inline tags like `<strong>`/`<em>`/`<a>` are kept; block tags are stripped.

## Cause

The `description` field is defined with `'sanitize' => 'wp_kses_post'`, which permits block-level HTML. In `Author_Editor::action_edited_author()` the value is correctly written via `update_user_meta()` with that `wp_kses_post` value — but for mapped users it is *also* added to `$updated_args` and passed to `wp_update_user()`. Core then runs the `pre_user_description` filter (`wp_filter_kses`, using the restrictive comment-level allowed tags), which strips `<p>`, headings, lists, etc., overwriting the good value.

## Fix

Exclude `description` from the `wp_update_user()` args. The `update_user_meta()` call immediately above already persisted the full `wp_kses_post` value, so the user's bio keeps its block-level HTML. All other fields are unchanged.

```php
if ($user_id) {
    update_user_meta($user_id, $key, $field_value);
    if ($key !== 'description') {
        $updated_args[$key] = $field_value;
    }
}
```

## Testing

1. Edit an author mapped to a WP user.
2. In Biographical Info (visual/WYSIWYG), add paragraphs, a heading, and a list.
3. Save and reload — block markup now persists, and renders in the author box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)