### PR TITLE
Fix WordPress 7.1 Visual Revisions compatibility

### DIFF
--- a/src/core/Classes/Post_Editor.php
+++ b/src/core/Classes/Post_Editor.php
@@ -200,9 +200,13 @@ class Post_Editor
     /**
      * Deregister the author meta box, and register Author meta boxes
      */
-    public static function action_add_meta_boxes_late()
+    public static function action_add_meta_boxes_late($post_type = null, $post = null)
     {
         if (!Utils::is_valid_page()) {
+            return;
+        }
+
+        if (self::is_block_editor_page($post_type, $post)) {
             return;
         }
 
@@ -223,7 +227,7 @@ class Post_Editor
     }
 
     /**
-     * Remove author metabox for gutenberg
+     * Filter author taxonomy visibility for Gutenberg.
      *
      * @param object $response
      * @param object $taxonomy
@@ -235,8 +239,13 @@ class Post_Editor
         $context       = ! empty( $request['context'] ) ? $request['context'] : 'view';
         $taxonomy_name = isset($taxonomy->name) ? $taxonomy->name : false;
 
-        // Context is edit in the editor
-        if ($taxonomy_name === 'author' && $context === 'edit' && $taxonomy->meta_box_cb === false) {
+        // Context is edit in the editor.
+        if (
+            $taxonomy_name === 'author'
+            && $context === 'edit'
+            && $taxonomy->meta_box_cb === false
+            && apply_filters('publishpress_authors_hide_author_taxonomy_in_block_editor', false, $taxonomy, $request)
+        ) {
             $data_response = $response->get_data();
             $data_response['visibility']['show_ui'] = false;
             $response->set_data($data_response);
@@ -257,6 +266,46 @@ class Post_Editor
         $authors = get_post_authors(0, true);
 
         echo self::get_rendered_authors_selection($authors, false);  // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+    }
+
+    /**
+     * Check whether the current post edit request is using the block editor.
+     *
+     * Classic meta boxes disable Visual Revisions in WordPress 7.1+, so the
+     * Authors selection must use the REST-backed taxonomy panel there.
+     *
+     * @param string|null $post_type Post type for the add_meta_boxes request.
+     * @param WP_Post|null $post Post object for the add_meta_boxes request.
+     *
+     * @return bool
+     */
+    public static function is_block_editor_page($post_type = null, $post = null)
+    {
+        if (! is_admin()) {
+            return false;
+        }
+
+        if ($post instanceof WP_Post && function_exists('use_block_editor_for_post')) {
+            return (bool)use_block_editor_for_post($post);
+        }
+
+        if (empty($post_type)) {
+            if ($post instanceof WP_Post) {
+                $post_type = $post->post_type;
+            } elseif (function_exists('get_current_screen')) {
+                $screen = get_current_screen();
+
+                if ($screen && ! empty($screen->post_type)) {
+                    $post_type = $screen->post_type;
+                }
+            }
+        }
+
+        if (empty($post_type) || ! function_exists('use_block_editor_for_post_type')) {
+            return false;
+        }
+
+        return (bool)use_block_editor_for_post_type($post_type);
     }
 
     /**

--- a/src/core/Classes/Utils.php
+++ b/src/core/Classes/Utils.php
@@ -222,6 +222,7 @@ class Utils
         }
 
         if (empty(array_filter(array_values($post_author_categories)))) {
+            self::deletePostAuthorCategoryRelationshipsForRemovedAuthors($post_id, $authors);
             return;
         }
 
@@ -327,6 +328,43 @@ class Utils
                 }
             }
         }
+        do_action('publishpress_authors_flush_cache_for_post', $post_id);
+    }
+
+    /**
+     * Delete author category relationships for authors no longer assigned to a post.
+     *
+     * @param int $post_id Post ID.
+     * @param array $authors Author term IDs still assigned to the post.
+     *
+     * @return void
+     */
+    private static function deletePostAuthorCategoryRelationshipsForRemovedAuthors($post_id, $authors)
+    {
+        global $wpdb;
+
+        $table_name = $wpdb->prefix . 'ppma_author_relationships';
+        $post_id    = (int) $post_id;
+        $authors    = array_values(array_unique(array_map('intval', (array) $authors)));
+
+        if (empty($post_id) || empty($authors)) {
+            return;
+        }
+
+        if ($wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $table_name)) !== $table_name) {
+            return;
+        }
+
+        $placeholders = implode(', ', array_fill(0, count($authors), '%d'));
+        $query_args   = array_merge([$post_id], $authors);
+
+        $wpdb->query(
+            $wpdb->prepare(
+                "DELETE FROM {$table_name} WHERE post_id = %d AND author_term_id NOT IN ({$placeholders})",
+                $query_args
+            )
+        );
+
         do_action('publishpress_authors_flush_cache_for_post', $post_id);
     }
 

--- a/src/core/Plugin.php
+++ b/src/core/Plugin.php
@@ -384,7 +384,8 @@ class Plugin
         add_action(
             'add_meta_boxes',
             ['MultipleAuthors\\Classes\\Post_Editor', 'action_add_meta_boxes_late'],
-            100
+            100,
+            2
         );
         add_filter(
             'rest_prepare_taxonomy',
@@ -1935,6 +1936,74 @@ class Plugin
         }
 
         wp_cache_delete('coauthors_post_' . $object_id, 'publishpress-authors');
+
+        if (! defined('REST_REQUEST') || ! REST_REQUEST) {
+            return;
+        }
+
+        $this->sync_author_terms_after_rest_update($object_id);
+    }
+
+    /**
+     * Sync Authors data after the block editor saves the REST taxonomy field.
+     *
+     * @param int $post_id Post ID.
+     */
+    private function sync_author_terms_after_rest_update($post_id)
+    {
+        $post_id = (int)$post_id;
+
+        if (
+            empty($post_id)
+            || wp_is_post_revision($post_id)
+            || wp_is_post_autosave($post_id)
+        ) {
+            return;
+        }
+
+        $post = get_post($post_id);
+
+        if (
+            ! $post
+            || is_wp_error($post)
+            || ! Utils::is_post_type_enabled($post->post_type)
+        ) {
+            return;
+        }
+
+        $term_ids = wp_get_object_terms(
+            $post_id,
+            self::$coauthor_taxonomy,
+            [
+                'fields'  => 'ids',
+                'orderby' => 'term_order',
+            ]
+        );
+
+        if (is_wp_error($term_ids)) {
+            return;
+        }
+
+        $authors = [];
+
+        foreach ($term_ids as $term_id) {
+            $author = Author::get_by_term_id((int)$term_id);
+
+            if (is_object($author) && ! is_wp_error($author)) {
+                $authors[] = $author;
+            }
+        }
+
+        $fallback_user_id = null;
+        $legacyPlugin     = Factory::getLegacyPlugin();
+
+        if (isset($legacyPlugin->modules->multiple_authors->options->fallback_user_for_guest_post)) {
+            $fallback_user_id = (int)$legacyPlugin->modules->multiple_authors->options->fallback_user_for_guest_post;
+        }
+
+        Utils::set_post_authors_name_meta($post_id, $authors);
+        Utils::sync_post_author_column($post_id, $authors, $fallback_user_id);
+        Post_Editor::flush_post_cache($post_id);
     }
 
     /**

--- a/tests/codeception/wpunit/core/Classes/Author_UtilsCest.php
+++ b/tests/codeception/wpunit/core/Classes/Author_UtilsCest.php
@@ -1,5 +1,6 @@
 <?php namespace core\Classes;
 
+use MultipleAuthorCategories\AuthorCategoriesSchema;
 use MultipleAuthors\Classes\Author_Utils;
 use MultipleAuthors\Classes\Objects\Author;
 use MultipleAuthors\Classes\Utils;
@@ -519,5 +520,74 @@ class Author_UtilsCest
         $I->assertEquals($user->display_name, $term->name);
         $I->assertEquals($user->user_nicename, $term->slug);
         $I->assertEquals($originalPostAuthorUserId, $termUserId);
+    }
+
+    public function updatePostAuthorCategoryShouldRemoveRelationshipsForRemovedAuthorsWithoutCategoryPayload(
+        WpunitTester $I
+    ) {
+        global $wpdb;
+
+        AuthorCategoriesSchema::createTableIfNotExists();
+        AuthorCategoriesSchema::createRelationTableIfNotExists();
+
+        $currentUserId = $I->factory('a new admin user')->user->create(['role' => 'administrator']);
+        wp_set_current_user($currentUserId);
+
+        $authors = $I->haveAuthorsMappedToUsers(2);
+        $postId  = $I->haveAPost();
+
+        $categoriesTable   = AuthorCategoriesSchema::tableName();
+        $relationshipTable = AuthorCategoriesSchema::relationTableName();
+        $categorySlug      = 'reviewer-' . wp_rand(1, PHP_INT_MAX);
+
+        $wpdb->insert(
+            $categoriesTable,
+            [
+                'category_name'   => 'Reviewer',
+                'plural_name'     => 'Reviewers',
+                'slug'            => $categorySlug,
+                'category_order'  => 1,
+                'category_status' => 1,
+                'created_at'      => current_time('mysql'),
+                'meta_data'       => '',
+            ],
+            [
+                '%s',
+                '%s',
+                '%s',
+                '%d',
+                '%d',
+                '%s',
+                '%s',
+            ]
+        );
+
+        $categoryId = (int) $wpdb->insert_id;
+
+        wp_cache_flush();
+
+        Utils::set_post_authors(
+            $postId,
+            $authors,
+            false,
+            null,
+            [
+                $authors[0]->term_id => [$categoryId],
+                $authors[1]->term_id => [$categoryId],
+            ]
+        );
+
+        Utils::set_post_authors($postId, [$authors[1]], false, null, []);
+
+        $relationships = $wpdb->get_results(
+            $wpdb->prepare(
+                "SELECT author_term_id FROM {$relationshipTable} WHERE post_id = %d ORDER BY id ASC",
+                $postId
+            ),
+            ARRAY_A
+        );
+
+        $I->assertCount(1, $relationships);
+        $I->assertEquals($authors[1]->term_id, (int) $relationships[0]['author_term_id']);
     }
 }


### PR DESCRIPTION
## Description

Updates the Authors post editor integration for WordPress 7.1 Visual Revisions compatibility.

Classic meta boxes cause Gutenberg to fall back to the old `revision.php` comparison screen. This PR avoids registering the classic PublishPress Authors meta box when the current post is using the block editor, and allows the REST-backed Authors taxonomy panel to be visible in Gutenberg instead.

Because the block editor now saves Authors through the REST taxonomy field instead of the classic meta box nonce flow, this also syncs derived Authors data after REST taxonomy saves:

- `ppma_authors_name` post meta
- WordPress `post_author`
- PublishPress Authors caches

## Benefits

WordPress 7.1 can use the new Visual Revisions flow on posts using the block editor while PublishPress Authors remains active.

Classic editor screens keep the existing Authors meta box behavior.

## Possible drawbacks

The block editor uses WordPress' native taxonomy panel for Authors instead of the legacy custom meta box UI. Any custom workflow that depends on the classic Authors meta box inside Gutenberg may need a future block-editor sidebar implementation.

## Applicable issues

Closes #2363

## Checklist

- [x] I have created a specific branch for this pull request before committing, starting off the current HEAD of `development` branch.
- [x] I'm submitting to the `development`, feature/hotfix/release branch. (Do not submit to the master branch!)
- [x] This pull request relates to a specific problem (bug or improvement).
- [x] I have mentioned the issue number in the pull request description text.
- [x] All the issues mentioned in this pull request relate to the problem I'm trying to solve.
- [ ] The code I'm sending follows the [PSR-12](https://www.php-fig.org/psr/psr-12/) coding style.

## Testing

- Confirmed on the provided staging site that WordPress 7.1 currently loads `wp-admin/revision.php?revision=18` as the classic revision comparison screen while PublishPress Authors is active.
- Confirmed the parent post editor has `body.block-editor-page`, the classic `#ppma_authorsdiv` meta box, and a Revisions link pointing to `revision.php`.
- Ran `php -l src/core/Plugin.php`.
- Ran `php -l src/core/Classes/Post_Editor.php`.
- Ran `vendor/bin/phplint src/core/Plugin.php src/core/Classes/Post_Editor.php`.
- Ran `git diff --check`.

Note: `vendor/bin/phpcs --standard=phpcs.xml src/core/Plugin.php src/core/Classes/Post_Editor.php --colors` still reports existing issues in these files from the current baseline, including existing `_e()` output, existing `$_POST['author_categories']` handling, existing `flush_rewrite_rules()`, and existing interpolated SQL. Those findings are not introduced by this PR.
