### PR TITLE
Add author box icon and display-name options

### DIFF
--- a/src/modules/author-boxes/assets/js/author-boxes-editor.js
+++ b/src/modules/author-boxes/assets/js/author-boxes-editor.js
@@ -654,7 +654,8 @@
                 'author_recent_posts_empty_show',
                 'author_recent_posts_limit',
                 'author_recent_posts_orderby',
-                'author_recent_posts_order'
+                'author_recent_posts_order',
+                'author_recent_posts_icon'
             ];
             var name_refresh_trigger = [
                 'name_show',
@@ -663,6 +664,7 @@
                 'name_author_categories_divider',
                 'name_author_categories_position',
                 'display_name_position',
+                'display_name_source',
                 'display_name_prefix',
                 'display_name_suffix'
             ];

--- a/src/modules/author-boxes/assets/js/author-boxes-editor.js
+++ b/src/modules/author-boxes/assets/js/author-boxes-editor.js
@@ -1251,7 +1251,7 @@
                         break;
                     case 'author_recent_posts_icon_color':
                         if (value) {
-                            editor_preview_styles += '.pp-multiple-authors-boxes-wrapper.' + additional_class + '  .pp-author-boxes-recent-posts-item span.dashicons { color: ' + value + ' !important; } ';
+                            editor_preview_styles += '.pp-multiple-authors-boxes-wrapper.' + additional_class + '  .pp-author-boxes-recent-posts-item span.dashicons, .pp-multiple-authors-boxes-wrapper.' + additional_class + '  .pp-author-boxes-recent-posts-item i.dashicons, .pp-multiple-authors-boxes-wrapper.' + additional_class + '  .pp-author-boxes-recent-posts-item i.fa, .pp-multiple-authors-boxes-wrapper.' + additional_class + '  .pp-author-boxes-recent-posts-item i.fas, .pp-multiple-authors-boxes-wrapper.' + additional_class + '  .pp-author-boxes-recent-posts-item i.far, .pp-multiple-authors-boxes-wrapper.' + additional_class + '  .pp-author-boxes-recent-posts-item i.fab { color: ' + value + ' !important; } ';
                         }
                         break;
                     //box layout styles

--- a/src/modules/author-boxes/author-boxes.php
+++ b/src/modules/author-boxes/author-boxes.php
@@ -1234,14 +1234,14 @@ class MA_Author_Boxes extends Module
      *
      * @return string
      */
-    public static function getAuthorBoxRecentPostsIcon($icon = '') {
-        if (empty($icon)) {
+    public static function getAuthorBoxRecentPostsIcon($icon = null) {
+        if (null === $icon) {
             $icon = '<span class="dashicons dashicons-media-text"></span>';
         }
 
-        $icon = wp_kses_post(html_entity_decode($icon));
+        $icon = wp_kses_post(html_entity_decode((string) $icon));
 
-        return !empty($icon) ? $icon : '<span class="dashicons dashicons-media-text"></span>';
+        return $icon;
     }
 
     /**
@@ -1641,7 +1641,7 @@ class MA_Author_Boxes extends Module
             $editor_data['display_name_source'] = 'display_name';
         }
 
-        if (empty($editor_data['author_recent_posts_icon'])) {
+        if (!isset($editor_data['author_recent_posts_icon'])) {
             $editor_data['author_recent_posts_icon'] = '<span class="dashicons dashicons-media-text"></span>';
         }
 
@@ -2253,7 +2253,11 @@ class MA_Author_Boxes extends Module
                                                         $display_name_suffix    = !empty($args['display_name_suffix']['value']) ? $args['display_name_suffix']['value'] : '';
                                                         $display_name_source    = (!empty($args['display_name_source']['value']) && is_string($args['display_name_source']['value'])) ? sanitize_key($args['display_name_source']['value']) : 'display_name';
                                                         $author_display_name    = self::getAuthorBoxDisplayName($author, $display_name_source);
-                                                        $recent_posts_icon      = !empty($args['author_recent_posts_icon']['value']) ? $args['author_recent_posts_icon']['value'] : '';
+                                                        $recent_posts_icon      = (
+                                                            isset($args['author_recent_posts_icon'])
+                                                            && is_array($args['author_recent_posts_icon'])
+                                                            && array_key_exists('value', $args['author_recent_posts_icon'])
+                                                        ) ? $args['author_recent_posts_icon']['value'] : null;
 
                                                         $display_name_markup = '';
                                                        if ($args['name_show']['value']) :

--- a/src/modules/author-boxes/author-boxes.php
+++ b/src/modules/author-boxes/author-boxes.php
@@ -1197,6 +1197,54 @@ class MA_Author_Boxes extends Module
     }
 
     /**
+     * Get the author name value selected for author box display.
+     *
+     * @param object $author Author object.
+     * @param string $source Selected display source.
+     *
+     * @return string
+     */
+    public static function getAuthorBoxDisplayName($author, $source = 'display_name') {
+        $source = is_string($source) ? sanitize_key($source) : 'display_name';
+        $display_name = (is_object($author) && isset($author->display_name)) ? $author->display_name : '';
+
+        if ('username' !== $source || !is_object($author)) {
+            return $display_name;
+        }
+
+        if (method_exists($author, 'get_user_object')) {
+            $user = $author->get_user_object();
+
+            if ($user instanceof WP_User && !empty($user->user_login)) {
+                return $user->user_login;
+            }
+        }
+
+        if (isset($author->user_login) && !empty($author->user_login)) {
+            return $author->user_login;
+        }
+
+        return $display_name;
+    }
+
+    /**
+     * Get the recent posts icon markup selected for author boxes.
+     *
+     * @param string $icon Icon markup.
+     *
+     * @return string
+     */
+    public static function getAuthorBoxRecentPostsIcon($icon = '') {
+        if (empty($icon)) {
+            $icon = '<span class="dashicons dashicons-media-text"></span>';
+        }
+
+        $icon = wp_kses_post(html_entity_decode($icon));
+
+        return !empty($icon) ? $icon : '<span class="dashicons dashicons-media-text"></span>';
+    }
+
+    /**
      * @param $html
      * @param $args
      *
@@ -1589,6 +1637,14 @@ class MA_Author_Boxes extends Module
             $editor_data['author_bio_html_tag'] = 'div';
         }
 
+        if (empty($editor_data['display_name_source'])) {
+            $editor_data['display_name_source'] = 'display_name';
+        }
+
+        if (empty($editor_data['author_recent_posts_icon'])) {
+            $editor_data['author_recent_posts_icon'] = '<span class="dashicons dashicons-media-text"></span>';
+        }
+
         // set boxed_categories defautlt fields
         if (
         isset($editor_data['author_categories_layout'])
@@ -1599,7 +1655,7 @@ class MA_Author_Boxes extends Module
         }
 
         //set social profile defaults
-        $social_fields = ['facebook', 'twitter', 'x', 'instagram', 'linkedin', 'youtube', 'tiktok'];
+        $social_fields = ['facebook', 'twitter', 'x', 'instagram', 'linkedin', 'pinterest', 'youtube', 'tiktok'];
         foreach ($social_fields as $social_field) {
             //set default display to icon
             if (!isset($editor_data['profile_fields_'.$social_field.'_display'])
@@ -2195,6 +2251,9 @@ class MA_Author_Boxes extends Module
                                                         $display_name_position    = !empty($args['display_name_position']['value']) ? $args['display_name_position']['value'] : 'after_avatar';
                                                         $display_name_prefix    = !empty($args['display_name_prefix']['value']) ? $args['display_name_prefix']['value'] : '';
                                                         $display_name_suffix    = !empty($args['display_name_suffix']['value']) ? $args['display_name_suffix']['value'] : '';
+                                                        $display_name_source    = (!empty($args['display_name_source']['value']) && is_string($args['display_name_source']['value'])) ? sanitize_key($args['display_name_source']['value']) : 'display_name';
+                                                        $author_display_name    = self::getAuthorBoxDisplayName($author, $display_name_source);
+                                                        $recent_posts_icon      = !empty($args['author_recent_posts_icon']['value']) ? $args['author_recent_posts_icon']['value'] : '';
 
                                                         $display_name_markup = '';
                                                        if ($args['name_show']['value']) :
@@ -2241,9 +2300,9 @@ class MA_Author_Boxes extends Module
                                                             endif;
                                                             $display_name_markup .= $before_name_author_category_content;
                                                             if (!$args['name_disable_link']['value']) {
-                                                                $display_name_markup .= '<a href="'. esc_url($author->link) .'" rel="author" title="'. esc_attr($author->display_name) .'" class="author url fn">';
+                                                                $display_name_markup .= '<a href="'. esc_url($author->link) .'" rel="author" title="'. esc_attr($author_display_name) .'" class="author url fn">';
                                                             }
-                                                            $display_name_markup .= esc_html($display_name_prefix . $author->display_name . $display_name_suffix);
+                                                            $display_name_markup .= esc_html($display_name_prefix . $author_display_name . $display_name_suffix);
                                                             if (!$args['name_disable_link']['value']) {
                                                                 $display_name_markup .= '</a>';
                                                             }
@@ -2349,7 +2408,7 @@ class MA_Author_Boxes extends Module
                                                                             <div class="pp-author-boxes-recent-posts-items">
                                                                                 <?php foreach($author_recent_posts as $recent_post_id) : ?>
                                                                                     <<?php echo esc_html($args['author_recent_posts_html_tag']['value']); ?> class="pp-author-boxes-recent-posts-item">
-                                                                                        <span class="dashicons dashicons-media-text"></span>
+                                                                                        <?php echo self::getAuthorBoxRecentPostsIcon($recent_posts_icon); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped by getAuthorBoxRecentPostsIcon(). ?>
                                                                                         <a href="<?php echo esc_url(get_the_permalink($recent_post_id)); ?>" title="<?php echo esc_attr(get_the_title($recent_post_id)); ?>">
                                                                                             <?php echo esc_html(html_entity_decode(get_the_title($recent_post_id))); ?>
                                                                                         </a>

--- a/src/modules/author-boxes/classes/AuthorBoxesAjax.php
+++ b/src/modules/author-boxes/classes/AuthorBoxesAjax.php
@@ -507,7 +507,11 @@ $display_name_source    = (!empty($args['display_name_source']['value']) && is_s
 if (!in_array($display_name_source, ['display_name', 'username'], true)) {
     $display_name_source = 'display_name';
 }
-$recent_posts_icon      = !empty($args['author_recent_posts_icon']['value']) ? $args['author_recent_posts_icon']['value'] : '';
+$recent_posts_icon      = (
+    isset($args['author_recent_posts_icon'])
+    && is_array($args['author_recent_posts_icon'])
+    && array_key_exists('value', $args['author_recent_posts_icon'])
+) ? $args['author_recent_posts_icon']['value'] : null;
 
 $display_name_markup = '';
                if ($args['name_show']['value']) :

--- a/src/modules/author-boxes/classes/AuthorBoxesAjax.php
+++ b/src/modules/author-boxes/classes/AuthorBoxesAjax.php
@@ -503,6 +503,11 @@ $meta_row_extra .= $meta_shortcode_output;
 $display_name_position    = !empty($args['display_name_position']['value']) ? $args['display_name_position']['value'] : 'after_avatar';
 $display_name_prefix    = !empty($args['display_name_prefix']['value']) ? $args['display_name_prefix']['value'] : '';
 $display_name_suffix    = !empty($args['display_name_suffix']['value']) ? $args['display_name_suffix']['value'] : '';
+$display_name_source    = (!empty($args['display_name_source']['value']) && is_string($args['display_name_source']['value'])) ? sanitize_key($args['display_name_source']['value']) : 'display_name';
+if (!in_array($display_name_source, ['display_name', 'username'], true)) {
+    $display_name_source = 'display_name';
+}
+$recent_posts_icon      = !empty($args['author_recent_posts_icon']['value']) ? $args['author_recent_posts_icon']['value'] : '';
 
 $display_name_markup = '';
                if ($args['name_show']['value']) :
@@ -548,9 +553,9 @@ $display_name_markup = '';
     endif;
     $display_name_markup .= str_repeat(" ", 32) . $before_name_author_category_content . str_repeat(" ", 32);
     if (!$args['name_disable_link']['value']) {
-    $display_name_markup .= '<a href="</?php echo esc_url($author->link); ?>" rel="author" title="</?php echo esc_attr($author->display_name); ?>" class="author url fn">';
+    $display_name_markup .= '<a href="</?php echo esc_url($author->link); ?>" rel="author" title="</?php echo esc_attr(MA_Author_Boxes::getAuthorBoxDisplayName($author, \'' . esc_html($display_name_source) . '\')); ?>" class="author url fn">';
     }
-    $display_name_markup .= "\n" . str_repeat(" ", 36) . $display_name_prefix . '</?php echo esc_html($author->display_name); ?>' . $display_name_suffix . "\n" . str_repeat(" ", 32);
+    $display_name_markup .= "\n" . str_repeat(" ", 36) . $display_name_prefix . '</?php echo esc_html(MA_Author_Boxes::getAuthorBoxDisplayName($author, \'' . esc_html($display_name_source) . '\')); ?>' . $display_name_suffix . "\n" . str_repeat(" ", 32);
     if (!$args['name_disable_link']['value']) {
     $display_name_markup .= '</a>';
     }
@@ -647,7 +652,7 @@ endif ?>
                                     <div class="pp-author-boxes-recent-posts-items">
                                         </?php foreach($author_recent_posts as $recent_post_id) : ?>
                                             <<?php echo esc_html($args['author_recent_posts_html_tag']['value']); ?> class="pp-author-boxes-recent-posts-item">
-                                                <span class="dashicons dashicons-media-text"></span>
+                                                <?php echo MA_Author_Boxes::getAuthorBoxRecentPostsIcon($recent_posts_icon); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped by getAuthorBoxRecentPostsIcon(). ?>
                                                 <a href="</?php echo esc_url(get_the_permalink($recent_post_id)); ?>" title="</?php echo esc_attr(get_the_title($recent_post_id)); ?>">
                                                     </?php echo esc_html(html_entity_decode(get_the_title($recent_post_id))); ?>
                                                 </a>

--- a/src/modules/author-boxes/classes/AuthorBoxesDefault.php
+++ b/src/modules/author-boxes/classes/AuthorBoxesDefault.php
@@ -220,6 +220,13 @@ class AuthorBoxesDefault
         $editor_data['profile_fields_linkedin_display_icon_background_color'] = '#655997';
         $editor_data['profile_fields_linkedin_color'] = '#ffffff';
         $editor_data['profile_fields_linkedin_display_icon_border_radius'] = 100;
+        // pinterest default
+        $editor_data['profile_fields_pinterest_html_tag'] = 'a';
+        $editor_data['profile_fields_pinterest_display'] = 'icon';
+        $editor_data['profile_fields_pinterest_display_icon'] = '<span class="dashicons dashicons-pinterest"></span>';
+        $editor_data['profile_fields_pinterest_display_icon_background_color'] = '#655997';
+        $editor_data['profile_fields_pinterest_color'] = '#ffffff';
+        $editor_data['profile_fields_pinterest_display_icon_border_radius'] = 100;
         // instagram default
         $editor_data['profile_fields_instagram_html_tag'] = 'a';
         $editor_data['profile_fields_instagram_display'] = 'icon';
@@ -334,7 +341,7 @@ class AuthorBoxesDefault
         // hide non essential author fields
         $profile_fields   = apply_filters('multiple_authors_author_fields', [], false);
         foreach ($profile_fields as $key => $data) {
-            if (!in_array($key, ['user_email', 'user_url', 'tiktok', 'youtube', 'linkedin', 'instagram', 'twitter', 'x', 'facebook', 'job_title'])) {
+            if (!in_array($key, ['user_email', 'user_url', 'tiktok', 'youtube', 'linkedin', 'pinterest', 'instagram', 'twitter', 'x', 'facebook', 'job_title'])) {
                 $editor_data['profile_fields_hide_' . $key] = 1;
             }
         }
@@ -699,7 +706,15 @@ class AuthorBoxesDefault
      */
     public static function addEditorDataDefaultValues($editor_data) {
         $profile_fields   = apply_filters('multiple_authors_author_fields', [], false);
-        $social_fields   = ['facebook', 'twitter', 'x', 'instagram', 'linkedin', 'youtube', 'user_url', 'user_email', 'tiktok'];
+        $social_fields   = ['facebook', 'twitter', 'x', 'instagram', 'linkedin', 'pinterest', 'youtube', 'user_url', 'user_email', 'tiktok'];
+
+        if (!isset($editor_data['display_name_source'])) {
+            $editor_data['display_name_source'] = 'display_name';
+        }
+
+        if (!isset($editor_data['author_recent_posts_icon'])) {
+            $editor_data['author_recent_posts_icon'] = '<span class="dashicons dashicons-media-text"></span>';
+        }
 
         foreach ($profile_fields as $key => $data) {
             if ($data['type'] === 'url' && !in_array($key, $social_fields)) {

--- a/src/modules/author-boxes/classes/AuthorBoxesEditorFields.php
+++ b/src/modules/author-boxes/classes/AuthorBoxesEditorFields.php
@@ -291,6 +291,16 @@ class AuthorBoxesEditorFields
             ],
             'tab'      => 'name',
         ];
+        $fields['display_name_source'] = [
+            'label'    => esc_html__('Display Name Source', 'publishpress-authors'),
+            'type'     => 'select',
+            'sanitize' => 'sanitize_text_field',
+            'options'  => [
+                'display_name' => esc_html__('Display Name', 'publishpress-authors'),
+                'username'     => esc_html__('Username', 'publishpress-authors'),
+            ],
+            'tab'      => 'name',
+        ];
         $fields['name_disable_link'] = [
             'label'    => esc_html__('Remove Display Name Link', 'publishpress-authors'),
             'type'     => 'checkbox',
@@ -1431,6 +1441,12 @@ class AuthorBoxesEditorFields
             'label'    => esc_html__('Recent Posts Icon Color', 'publishpress-authors'),
             'type'     => 'color',
             'sanitize' => 'sanitize_text_field',
+            'tab'      => 'author_recent_posts',
+        ];
+        $fields['author_recent_posts_icon'] = [
+            'label'    => esc_html__('Recent Posts Icon', 'publishpress-authors'),
+            'type'     => 'icon',
+            'sanitize' => ['stripslashes_deep', 'wp_kses_post'],
             'tab'      => 'author_recent_posts',
         ];
         $fields['author_recent_posts_html_tag'] = [

--- a/src/modules/author-boxes/classes/AuthorBoxesStyles.php
+++ b/src/modules/author-boxes/classes/AuthorBoxesStyles.php
@@ -497,7 +497,12 @@ class AuthorBoxesStyles
     }' . "\n" . "\n";
         }
         if (!empty($args['author_recent_posts_icon_color']['value'])) {
-            $custom_styles .= '    .pp-multiple-authors-boxes-wrapper.'.$args['additional_class'].' .pp-author-boxes-recent-posts-item span.dashicons {
+            $custom_styles .= '    .pp-multiple-authors-boxes-wrapper.'.$args['additional_class'].' .pp-author-boxes-recent-posts-item span.dashicons,
+    .pp-multiple-authors-boxes-wrapper.'.$args['additional_class'].' .pp-author-boxes-recent-posts-item i.dashicons,
+    .pp-multiple-authors-boxes-wrapper.'.$args['additional_class'].' .pp-author-boxes-recent-posts-item i.fa,
+    .pp-multiple-authors-boxes-wrapper.'.$args['additional_class'].' .pp-author-boxes-recent-posts-item i.fas,
+    .pp-multiple-authors-boxes-wrapper.'.$args['additional_class'].' .pp-author-boxes-recent-posts-item i.far,
+    .pp-multiple-authors-boxes-wrapper.'.$args['additional_class'].' .pp-author-boxes-recent-posts-item i.fab {
         color: '. $args['author_recent_posts_icon_color']['value'] .' !important; 
     }' . "\n" . "\n";
         }

--- a/src/modules/author-custom-fields/author-custom-fields.php
+++ b/src/modules/author-custom-fields/author-custom-fields.php
@@ -1133,7 +1133,7 @@ class MA_Author_Custom_Fields extends Module
             }
             // filter out social fields if pro is not active
             if (!Utils::isAuthorsProActive() && isset($_GET['post_type']) && $_GET['post_type'] == self::POST_TYPE_CUSTOM_FIELDS) {
-                $social_field_names = ['facebook', 'x', 'instagram', 'linkedIn', 'youtube', 'tiktok'];
+                $social_field_names = ['facebook', 'x', 'instagram', 'linkedIn', 'pinterest', 'youtube', 'tiktok'];
 
                 $meta_query = $query->get('meta_query') ?: [];
                 $meta_query[] = [
@@ -1237,6 +1237,15 @@ class MA_Author_Custom_Fields extends Module
             'social_profile'  => 1,
             'field_status'  => 'off',
             'description'  => __('Please enter the full URL to your Instagram page.', 'publishpress-authors'),
+        ];
+        //add Pinterest
+        $social_custom_fields['pinterest'] = [
+            'post_title'   => __('Pinterest', 'publishpress-authors'),
+            'post_name'    => 'pinterest',
+            'type'         => 'url',
+            'social_profile'  => 1,
+            'field_status'  => 'off',
+            'description'  => __('Please enter the full URL to your Pinterest profile.', 'publishpress-authors'),
         ];
         //add LinkedIn
         $social_custom_fields['linkedIn'] = [


### PR DESCRIPTION
## Summary
- Add an Author Box display name source setting with a Username option and fallback to the existing display name for guest/unmapped authors.
- Add a Recent Posts icon picker for Author Boxes and use the selected icon in frontend output and generated templates.
- Add Pinterest to the free-side Pro social-field scaffolding and Author Box social defaults.

Refs discussions #1483, #1716, and #1211.

## Validation
- php -l on changed PHP files
- vendor/bin/phplint on changed PHP files
- node --check src/modules/author-boxes/assets/js/author-boxes-editor.js
- git diff --check

Note: changed-file PHPCS was attempted after installing dev dependencies with --ignore-platform-req=php because local PHP is 8.5.9 while the lock file allows up to 8.4 for one Codeception dependency. PHPCS still reports existing PSR12 violations in the touched legacy files.