### PR TITLE
Fix: create author-categories tables for new Multisite sub-sites

### DIFF
--- a/src/modules/author-categories/author-categories.php
+++ b/src/modules/author-categories/author-categories.php
@@ -106,6 +106,41 @@ class MA_Author_Categories extends Module
         add_filter('removable_query_args', [$this, 'removableQueryArgs']);
         add_action('delete_post', [$this, 'deleteAuthorCategoryRelation']);
         add_action('publishpress_author_categories_flush_cache', [$this, 'flush_cache'], 15);
+        add_action('wp_initialize_site', [$this, 'createTablesForNewNetworkSite'], 100);
+    }
+
+    /**
+     * Create the plugin's custom tables for a newly created Multisite sub-site.
+     *
+     * On Multisite the custom tables are created per-site by the installer, but a
+     * newly created sub-site never runs that installer, so its author-categories
+     * tables are missing and any query against them fails. This hooks
+     * wp_initialize_site (WP 5.1+) to run the install tasks on the new site when
+     * the plugin is network-active.
+     *
+     * @param \WP_Site $new_site The new site object.
+     *
+     * @return void
+     */
+    public function createTablesForNewNetworkSite($new_site)
+    {
+        if (!is_multisite() || !is_a($new_site, 'WP_Site')) {
+            return;
+        }
+
+        if (!function_exists('is_plugin_active_for_network')) {
+            require_once ABSPATH . 'wp-admin/includes/plugin.php';
+        }
+
+        // Only act when the plugin is network-active; otherwise the new sub-site
+        // is not running this plugin and should not get its tables.
+        if (!is_plugin_active_for_network(PP_AUTHORS_FILE)) {
+            return;
+        }
+
+        switch_to_blog((int) $new_site->blog_id);
+        $this->runInstallTasks(PP_AUTHORS_VERSION);
+        restore_current_blog();
     }
 
     /**


### PR DESCRIPTION
## Problem

On Multisite, the **author-categories** module creates three custom DB tables per site (`{$wpdb->prefix}ppma_author_categories`, `..._meta`, `ppma_author_relationships`) inside its install/upgrade tasks. A newly created sub-site never runs those tasks, so its tables are missing. Any query against them — e.g. on the front end before an admin first visits `wp-admin` on the new site — fails with a SQL error.

Flagged by static analysis: *"Plugin creates custom database tables in `AuthorCategoriesSchema.php` but does not hook into `wpmu_new_blog` / `wp_initialize_site`. New sites in a Multisite network will not have the plugin's tables."*

## Fix

Hook `wp_initialize_site` (WP 5.1+) and run the module's existing `runInstallTasks()` on the newly created site under `switch_to_blog()`, so the per-site-prefixed tables are created for the new blog. Guarded to only fire when the plugin is network-active (`is_plugin_active_for_network(PP_AUTHORS_FILE)`).

Reusing `runInstallTasks()` means the new site also gets the default categories and the `ppma_manage_author_categories` capability, matching a normal per-site install. `createTableIfNotExists()` already guards against duplicate table creation.

```php
add_action('wp_initialize_site', [$this, 'createTablesForNewNetworkSite'], 100);

public function createTablesForNewNetworkSite($new_site)
{
    if (!is_multisite() || !is_a($new_site, 'WP_Site')) {
        return;
    }
    if (!function_exists('is_plugin_active_for_network')) {
        require_once ABSPATH . 'wp-admin/includes/plugin.php';
    }
    if (!is_plugin_active_for_network(PP_AUTHORS_FILE)) {
        return;
    }
    switch_to_blog((int) $new_site->blog_id);
    $this->runInstallTasks(PP_AUTHORS_VERSION);
    restore_current_blog();
}
```

## Testing

1. Network-activate PublishPress Authors on a Multisite install.
2. Create a new sub-site (Network Admin → Sites → Add New).
3. Confirm the three `ppma_*` tables exist for the new site's table prefix and default author categories are present — no missing-table errors on the new site's front end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)