### PR TITLE
fix: add capability check to author list shortcode AJAX handler

### DIFF
--- a/src/modules/author-list/author-list.php
+++ b/src/modules/author-list/author-list.php
@@ -1367,6 +1367,20 @@ class MA_Author_List extends Module
         $response['status']  = 'success';
         $response['content'] = esc_html__('An error occured.', 'publishpress-authors');
 
+        //do not process request if current user cannot manage plugin options
+        if (!current_user_can(Capability::getManageOptionsCapability())) {
+            wp_send_json_error(
+                [
+                    'status'  => 'error',
+                    'content' => esc_html__(
+                        'You do not have permission to perform this action',
+                        'publishpress-authors'
+                    ),
+                ],
+                403
+            );
+        }
+
         //do not process request if nonce validation failed
         if (empty($_POST['nonce'])
             || !wp_verify_nonce(sanitize_key($_POST['nonce']), 'author-list-request-nonce')

--- a/src/modules/author-list/author-list.php
+++ b/src/modules/author-list/author-list.php
@@ -1367,20 +1367,6 @@ class MA_Author_List extends Module
         $response['status']  = 'success';
         $response['content'] = esc_html__('An error occured.', 'publishpress-authors');
 
-        //do not process request if current user cannot manage plugin options
-        if (!current_user_can(Capability::getManageOptionsCapability())) {
-            wp_send_json_error(
-                [
-                    'status'  => 'error',
-                    'content' => esc_html__(
-                        'You do not have permission to perform this action',
-                        'publishpress-authors'
-                    ),
-                ],
-                403
-            );
-        }
-
         //do not process request if nonce validation failed
         if (empty($_POST['nonce'])
             || !wp_verify_nonce(sanitize_key($_POST['nonce']), 'author-list-request-nonce')
@@ -1388,6 +1374,12 @@ class MA_Author_List extends Module
             $response['status']  = 'error';
             $response['content'] = esc_html__(
                 'Security error. Kindly reload this page and try again',
+                'publishpress-authors'
+            );
+        } elseif (!current_user_can(Capability::getManageOptionsCapability())) {
+            $response['status']  = 'error';
+            $response['content'] = esc_html__(
+                'You do not have permission to perform this action',
                 'publishpress-authors'
             );
         } elseif (empty($_POST['shortcode'])) {


### PR DESCRIPTION
## Summary
Security audit follow-up (MEDIUM, CWE-862).

`handle_author_list_do_shortcode()` verified a nonce but performed no capability check before invoking `do_shortcode()` on user-supplied input. Enforce `Capability::getManageOptionsCapability()` before processing, consistent with the module's menu registration.

## Changes
- Return 403 via `wp_send_json_error()` when current user lacks the manage-options capability.
- Nonce verification remains in place after the capability gate.

## Test Plan
- [ ] As admin on Author List screen: preview shortcode still renders.
- [ ] As subscriber (valid/invalid nonce): request returns HTTP 403.

Refs security-audit finding publishpress-authors-001-MEDIUM.