### PR TITLE
fix: restrict unauthenticated access to user-mapped authors on REST read route

### DIFF
--- a/src/modules/rest-api/rest-api.php
+++ b/src/modules/rest-api/rest-api.php
@@ -149,7 +149,34 @@ if (!class_exists('MA_REST_API')) {
 
         public function checkReadPermissions($request)
         {
-            return true;
+            if (current_user_can('ppma_manage_authors')) {
+                return true;
+            }
+
+            // Allow unauthenticated read only for publicly viewable authors.
+            return $this->isPubliclyViewableAuthor((int) $request['id']);
+        }
+
+        /**
+         * Check whether an author term is safe to expose publicly:
+         * it must belong to the author taxonomy and not be mapped to
+         * a real user account (user-linked authors can carry user meta).
+         *
+         * @param int $author_id Author term ID.
+         *
+         * @return bool
+         */
+        private function isPubliclyViewableAuthor($author_id)
+        {
+            $term = get_term($author_id, 'author');
+
+            if (!$term || is_wp_error($term)) {
+                return false;
+            }
+
+            $user_id = get_term_meta($author_id, 'user_id', true);
+
+            return empty((int) $user_id);
         }
 
         public function getCreateAuthorArgs()


### PR DESCRIPTION
## Summary
Security audit follow-up (MEDIUM, CWE-862).

GET `/publishpress-authors/v1/authors/{id}` used `checkReadPermissions()` returning `true` unconditionally, exposing any author term to anonymous clients — including user-linked author records that can carry contact meta.

## Changes
- Full read access retained for users with `ppma_manage_authors`.
- Unauthenticated/low-privilege reads allowed only for guest authors (no mapped `user_id` term meta) and valid author-taxonomy terms.
- Invalid or non-author terms return 403 via the permission callback.

## Test Plan
- [ ] Anonymous GET of a guest author term → 200.
- [ ] Anonymous GET of a user-mapped author term → 403.
- [ ] Editor/admin with `ppma_manage_authors` GET of any author → 200.

Refs security-audit finding publishpress-authors-002-MEDIUM.