### PR TITLE
chore: bump minimum PHP version requirement to 7.4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {
-    "php": ">=7.2.5"
+    "php": ">=7.4.0"
   },
   "require-dev": {
     "publishpress/dev-workspace": "^1.0"

--- a/lib/composer.json
+++ b/lib/composer.json
@@ -10,7 +10,7 @@
     "autoloader-suffix": "PPAuthors"
   },
   "require": {
-    "php": ">=7.2.5",
+    "php": ">=7.4.0",
     "publishpress/psr-container": "^2.0",
     "publishpress/pimple-pimple": "^3.5",
     "publishpress/wordpress-version-notices": "^2.1",

--- a/publishpress-authors.php
+++ b/publishpress-authors.php
@@ -9,7 +9,7 @@
  * Text Domain: publishpress-authors
  * Domain Path: /languages
  * Requires at least: 5.5
- * Requires PHP: 7.2.5
+ * Requires PHP: 7.4.0
  *
  * ------------------------------------------------------------------------------
  * Based on Co-Authors Plus.
@@ -45,7 +45,7 @@ use MultipleAuthors\Plugin;
 
 global $wp_version;
 
-$min_php_version = '7.2.5';
+$min_php_version = '7.4.0';
 $min_wp_version  = '5.5';
 
 // If the PHP or WP version is not compatible, terminate the plugin execution.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Author: PublishPress
 Author URI: https://publishpress.com
 Tags: multiple authors, authors, guest authors, author bio, author layouts
 Requires at least: 5.5
-Requires PHP: 7.2.5
+Requires PHP: 7.4.0
 Tested up to: 7.0
 Stable tag: 4.15.0
 License: GPLv2 or later


### PR DESCRIPTION
## Summary
Security audit follow-up (LOW, CWE-1104).

PHP 7.2/7.3 are end-of-life and no longer receive security patches. Bump the declared minimum PHP version from 7.2.5 to 7.4.0 across all manifests, updated together for consistency.

## Changes
- `publishpress-authors.php`: `Requires PHP` header (line 12) and `$min_php_version` bootstrap variable (line 48).
- `composer.json`: `require.php`.
- `lib/composer.json`: `require.php`.
- `readme.txt`: `Requires PHP`.

## Test Plan
- [ ] CI test matrix includes PHP 7.4.
- [ ] Plugin activates on PHP 7.4+ and blocks gracefully below it.

Refs security-audit finding publishpress-authors-003-LOW.