### PR TITLE
Set Simple List author box border style to none

### DIFF
--- a/src/modules/author-boxes/classes/AuthorBoxesDefault.php
+++ b/src/modules/author-boxes/classes/AuthorBoxesDefault.php
@@ -648,7 +648,7 @@ class AuthorBoxesDefault
         $editor_data['author_recent_posts_title_border_bottom_style'] = 'dotted';
         $editor_data['author_recent_posts_alignment'] = 'left';
         //box layout default
-        $editor_data['box_layout_border_style'] = 'solid';
+        $editor_data['box_layout_border_style'] = 'none';
         $editor_data['box_layout_border_color'] = '#999999';
         $editor_data['box_layout_shadow_horizontal_offset'] = 10;
         $editor_data['box_layout_shadow_vertical_offset'] = 10;


### PR DESCRIPTION
## Summary
- Change the default Author Box Border Style for the Simple List author box preset from Solid to None.

## Testing
- php -l src/modules/author-boxes/classes/AuthorBoxesDefault.php
- git diff --check
- /Users/steveburge/Documents/New\ project/publishpress-authors-author-list-layouts/vendor/bin/phplint src/modules/author-boxes/classes/AuthorBoxesDefault.php
- /Users/steveburge/Documents/New\ project/publishpress-authors-author-list-layouts/vendor/bin/phpcs --standard=phpcs.xml src/modules/author-boxes/classes/AuthorBoxesDefault.php