### PR TITLE
Update Simple List author box defaults

### DIFF
--- a/src/modules/author-boxes/classes/AuthorBoxesDefault.php
+++ b/src/modules/author-boxes/classes/AuthorBoxesDefault.php
@@ -621,11 +621,12 @@ class AuthorBoxesDefault
         $editor_data['box_tab_custom_wrapper_class'] = 'pp-multiple-authors-layout-simple_list';
         //avatar default
         $editor_data['avatar_show'] = 1;
-        $editor_data['avatar_size'] = 35;
+        $editor_data['avatar_size'] = 100;
         $editor_data['avatar_border_radius'] = 0;
         //name default
         $editor_data['name_show'] = 1;
         $editor_data['name_disable_link'] = 0;
+        $editor_data['name_style'] = '';
         $editor_data['name_html_tag'] = 'div';
         //bio default
         $editor_data['author_bio_html_tag'] = 'div';
@@ -648,6 +649,8 @@ class AuthorBoxesDefault
         $editor_data['author_recent_posts_title_border_bottom_style'] = 'dotted';
         $editor_data['author_recent_posts_alignment'] = 'left';
         //box layout default
+        $editor_data['box_layout_margin_top'] = 15;
+        $editor_data['box_layout_margin_bottom'] = 15;
         $editor_data['box_layout_border_style'] = 'solid';
         $editor_data['box_layout_border_color'] = '#999999';
         $editor_data['box_layout_shadow_horizontal_offset'] = 10;


### PR DESCRIPTION
## Summary
- Set Simple List Display Name Style to the Default option.
- Increase Simple List avatar size from 35px to 100px.
- Set Simple List author box top and bottom margins to 15px.

## Testing
- php -l src/modules/author-boxes/classes/AuthorBoxesDefault.php
- git diff --check
- /Users/steveburge/Documents/New\ project/publishpress-authors-author-list-layouts/vendor/bin/phplint src/modules/author-boxes/classes/AuthorBoxesDefault.php
- /Users/steveburge/Documents/New\ project/publishpress-authors-author-list-layouts/vendor/bin/phpcs --standard=phpcs.xml src/modules/author-boxes/classes/AuthorBoxesDefault.php