### PR TITLE
Add PublishPress Authors Elementor widgets (Authors Box + Authors List)

### DIFF
--- a/src/core/Classes/Utils.php
+++ b/src/core/Classes/Utils.php
@@ -788,14 +788,29 @@ class Utils
 
     public static function isElementorInstalled()
     {
-        // For now we only integrate with the Pro version because the Free one doesn't have the posts modules.
+        // Free Elementor is enough for the Authors List widget. The Pro-only
+        // skins are conditionally registered inside the integration module.
 
-        if (! defined('ELEMENTOR_PRO_VERSION')) {
+        if (! defined('ELEMENTOR_VERSION')) {
             return false;
         }
 
-        if (version_compare(ELEMENTOR_PRO_VERSION, '2.9.3', '<')) {
+        if (version_compare(ELEMENTOR_VERSION, '2.9.3', '<')) {
             return false;
+        }
+
+        if (! class_exists('\\Elementor\\Widget_Base')) {
+            return false;
+        }
+
+        // The posts/archive skins require Elementor Pro. Without it we still
+        // load the module (for the free widgets) but skip the Pro skins.
+        if (! defined('ELEMENTOR_PRO_VERSION')) {
+            return true;
+        }
+
+        if (version_compare(ELEMENTOR_PRO_VERSION, '2.9.3', '<')) {
+            return true;
         }
 
         $abort = false;

--- a/src/modules/elementor-integration/Modules/AuthorsBox/AuthorsBoxWidget.php
+++ b/src/modules/elementor-integration/Modules/AuthorsBox/AuthorsBoxWidget.php
@@ -1,0 +1,191 @@
+<?php
+/**
+ * @package PublishPress Authors
+ * @author  PublishPress
+ *
+ * Copyright (C) 2018 PublishPress
+ *
+ * This file is part of PublishPress Authors
+ *
+ * PublishPress Authors is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * PublishPress is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PublishPress.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace PublishPressAuthors\ElementorIntegration\Modules\AuthorsBox;
+
+use Elementor\Widget_Base;
+use Elementor\Controls_Manager;
+use MultipleAuthors\Factory;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Class AuthorsBoxWidget
+ *
+ * An Elementor widget that renders a PublishPress Authors box,
+ * mirroring the "PublishPress Authors Box" Gutenberg block: it offers a
+ * select of the saved author boxes (Authors > Author Boxes) and renders
+ * the chosen box through the [publishpress_authors_box] shortcode.
+ *
+ * @package PublishPressAuthors\ElementorIntegration\Modules\AuthorsBox
+ */
+class AuthorsBoxWidget extends Widget_Base
+{
+    /**
+     * @inheritDoc
+     */
+    public function get_name()
+    {
+        return 'publishpress_authors_box';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function get_title()
+    {
+        return __('PublishPress Authors Box', 'publishpress-authors');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function get_icon()
+    {
+        return 'eicon-user-card';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function get_categories()
+    {
+        return ['general'];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function get_keywords()
+    {
+        return ['author', 'authors', 'publishpress', 'box', 'bio', 'byline', 'profile'];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function register_controls()
+    {
+        $this->start_controls_section(
+            'section_content',
+            [
+                'label' => __('Authors Box', 'publishpress-authors'),
+            ]
+        );
+
+        $this->add_control(
+            'selected_box_id',
+            [
+                'label'       => __('Select an author box', 'publishpress-authors'),
+                'type'        => Controls_Manager::SELECT,
+                'options'     => $this->get_author_boxes_options(),
+                'default'     => $this->get_default_box_id(),
+                'description' => __(
+                    'Choose one of the author boxes created under Authors > Author Boxes.',
+                    'publishpress-authors'
+                ),
+            ]
+        );
+
+        $this->end_controls_section();
+    }
+
+    /**
+     * Build the select options from the saved author boxes.
+     *
+     * @return array
+     */
+    private function get_author_boxes_options()
+    {
+        $options = [];
+
+        $boxes = $this->get_author_boxes();
+
+        foreach ($boxes as $boxId => $boxTitle) {
+            $options[$boxId] = $boxTitle;
+        }
+
+        if (empty($options)) {
+            $options['boxed'] = __('Boxed (default)', 'publishpress-authors');
+        }
+
+        return $options;
+    }
+
+    /**
+     * The saved author boxes as "author_boxes_<id>" => title.
+     *
+     * @return array
+     */
+    private function get_author_boxes()
+    {
+        $boxes = [];
+
+        try {
+            $legacyPlugin = Factory::getLegacyPlugin();
+        } catch (\Exception $e) {
+            $legacyPlugin = null;
+        }
+
+        if ($legacyPlugin && isset($legacyPlugin->modules->author_boxes)
+            && class_exists('\MA_Author_Boxes')) {
+            $boxes = \MA_Author_Boxes::getAuthorBoxes(false);
+        }
+
+        return is_array($boxes) ? $boxes : [];
+    }
+
+    /**
+     * Default to the first saved box, like the Gutenberg block does.
+     *
+     * @return string
+     */
+    private function get_default_box_id()
+    {
+        $boxes = $this->get_author_boxes();
+
+        if (!empty($boxes)) {
+            return (string)array_key_first($boxes);
+        }
+
+        return 'boxed';
+    }
+
+    /**
+     * Render the author box using the plugin shortcode.
+     */
+    protected function render()
+    {
+        $settings = $this->get_settings_for_display();
+
+        $layout = !empty($settings['selected_box_id'])
+            ? sanitize_text_field($settings['selected_box_id'])
+            : 'boxed';
+
+        echo do_shortcode(
+            sprintf('[publishpress_authors_box layout="%s"]', esc_attr($layout))
+        );
+    }
+}

--- a/src/modules/elementor-integration/Modules/AuthorsBox/AuthorsBoxWidget.php
+++ b/src/modules/elementor-integration/Modules/AuthorsBox/AuthorsBoxWidget.php
@@ -166,8 +166,8 @@ class AuthorsBoxWidget extends Widget_Base
     {
         $boxes = $this->get_author_boxes();
 
-        if (!empty($boxes)) {
-            return (string)array_key_first($boxes);
+        foreach ($boxes as $boxId => $boxTitle) {
+            return (string)$boxId;
         }
 
         return 'boxed';

--- a/src/modules/elementor-integration/Modules/AuthorsBox/AuthorsBoxWidget.php
+++ b/src/modules/elementor-integration/Modules/AuthorsBox/AuthorsBoxWidget.php
@@ -84,6 +84,16 @@ class AuthorsBoxWidget extends Widget_Base
     }
 
     /**
+     * Make sure the authors layout CSS is loaded in the editor and frontend.
+     *
+     * @return array
+     */
+    public function get_style_depends()
+    {
+        return ['multiple-authors-widget-css'];
+    }
+
+    /**
      * @inheritDoc
      */
     protected function register_controls()

--- a/src/modules/elementor-integration/Modules/AuthorsBox/AuthorsBoxWidget.php
+++ b/src/modules/elementor-integration/Modules/AuthorsBox/AuthorsBoxWidget.php
@@ -64,7 +64,7 @@ class AuthorsBoxWidget extends Widget_Base
      */
     public function get_icon()
     {
-        return 'eicon-user-card';
+        return 'eicon-user-circle-o';
     }
 
     /**

--- a/src/modules/elementor-integration/Modules/AuthorsList/AuthorsListWidget.php
+++ b/src/modules/elementor-integration/Modules/AuthorsList/AuthorsListWidget.php
@@ -82,6 +82,16 @@ class AuthorsListWidget extends Widget_Base
     }
 
     /**
+     * Make sure the authors layout CSS is loaded in the editor and frontend.
+     *
+     * @return array
+     */
+    public function get_style_depends()
+    {
+        return ['multiple-authors-widget-css'];
+    }
+
+    /**
      * List of author list layouts available.
      *
      * @return array

--- a/src/modules/elementor-integration/Modules/AuthorsList/AuthorsListWidget.php
+++ b/src/modules/elementor-integration/Modules/AuthorsList/AuthorsListWidget.php
@@ -34,8 +34,9 @@ if (!defined('ABSPATH')) {
 /**
  * Class AuthorsListWidget
  *
- * An Elementor widget that renders the PublishPress Authors list,
- * reusing the same layouts as the [publishpress_authors_list] shortcode.
+ * An Elementor widget that renders one of the saved author lists
+ * (Authors > Author Lists), mirroring the [publishpress_authors_list]
+ * shortcode with a list_id parameter.
  *
  * @package PublishPressAuthors\ElementorIntegration\Modules\AuthorsList
  */
@@ -78,7 +79,7 @@ class AuthorsListWidget extends Widget_Base
      */
     public function get_keywords()
     {
-        return ['author', 'authors', 'publishpress', 'byline', 'user', 'users'];
+        return ['author', 'authors', 'publishpress', 'list', 'byline', 'user', 'users'];
     }
 
     /**
@@ -92,32 +93,10 @@ class AuthorsListWidget extends Widget_Base
     }
 
     /**
-     * List of author list layouts available.
-     *
-     * @return array
-     */
-    private function get_layouts()
-    {
-        $layouts = [
-            'authors_index'  => __('Authors Index', 'publishpress-authors'),
-            'authors_recent' => __('Authors Recent', 'publishpress-authors'),
-            'boxed'          => __('Boxed', 'publishpress-authors'),
-            'inline'         => __('Inline', 'publishpress-authors'),
-            'inline_avatars' => __('Inline Avatars', 'publishpress-authors'),
-            'simple_list'    => __('Simple List', 'publishpress-authors'),
-        ];
-
-        return apply_filters('publishpress_authors_elementor_widget_layouts', $layouts);
-    }
-
-    /**
      * @inheritDoc
      */
     protected function register_controls()
     {
-        // ------------------------------------------
-        // Content section
-        // ------------------------------------------
         $this->start_controls_section(
             'section_content',
             [
@@ -128,105 +107,14 @@ class AuthorsListWidget extends Widget_Base
         $this->add_control(
             'list_id',
             [
-                'label'       => __('Author List', 'publishpress-authors'),
+                'label'       => __('Select an author list', 'publishpress-authors'),
                 'type'        => Controls_Manager::SELECT,
-                'options'     => $this->get_saved_author_lists(),
+                'options'     => $this->get_author_list_options(),
+                'default'     => $this->get_default_list_id(),
                 'description' => __(
-                    'Optionally pick a saved author list created under Authors > Author Lists. Its settings override the options below.',
+                    'Choose one of the author lists created under Authors > Author Lists.',
                     'publishpress-authors'
                 ),
-            ]
-        );
-
-        $this->add_control(
-            'layout',
-            [
-                'label'   => __('Layout', 'publishpress-authors'),
-                'type'    => Controls_Manager::SELECT,
-                'default' => 'authors_index',
-                'options' => $this->get_layouts(),
-            ]
-        );
-
-        $this->add_control(
-            'orderby',
-            [
-                'label'   => __('Order By', 'publishpress-authors'),
-                'type'    => Controls_Manager::SELECT,
-                'default' => 'name',
-                'options' => [
-                    'name'       => __('Name', 'publishpress-authors'),
-                    'count'      => __('Post Count', 'publishpress-authors'),
-                    'first_name' => __('First Name', 'publishpress-authors'),
-                    'last_name'  => __('Last Name', 'publishpress-authors'),
-                ],
-            ]
-        );
-
-        $this->add_control(
-            'order',
-            [
-                'label'   => __('Order', 'publishpress-authors'),
-                'type'    => Controls_Manager::SELECT,
-                'default' => 'asc',
-                'options' => [
-                    'asc'  => __('Ascending', 'publishpress-authors'),
-                    'desc' => __('Descending', 'publishpress-authors'),
-                ],
-            ]
-        );
-
-        $this->add_control(
-            'limit_per_page',
-            [
-                'label'       => __('Limit Per Page', 'publishpress-authors'),
-                'type'        => Controls_Manager::NUMBER,
-                'min'         => 0,
-                'default'     => 20,
-                'description' => __('Leave 0 to show all authors.', 'publishpress-authors'),
-            ]
-        );
-
-        $this->add_control(
-            'show_empty',
-            [
-                'label'     => __('Show Authors Without Posts', 'publishpress-authors'),
-                'type'      => Controls_Manager::SWITCHER,
-                'label_on'  => __('Yes', 'publishpress-authors'),
-                'label_off' => __('No', 'publishpress-authors'),
-                'default'   => 'yes',
-            ]
-        );
-
-        $this->add_control(
-            'search_box',
-            [
-                'label'     => __('Show Search Box', 'publishpress-authors'),
-                'type'      => Controls_Manager::SWITCHER,
-                'label_on'  => __('Yes', 'publishpress-authors'),
-                'label_off' => __('No', 'publishpress-authors'),
-                'default'   => '',
-            ]
-        );
-
-        $this->add_control(
-            'show_title',
-            [
-                'label'     => __('Show Title', 'publishpress-authors'),
-                'type'      => Controls_Manager::SWITCHER,
-                'label_on'  => __('Yes', 'publishpress-authors'),
-                'label_off' => __('No', 'publishpress-authors'),
-                'default'   => '',
-            ]
-        );
-
-        $this->add_control(
-            'title',
-            [
-                'label'       => __('Title', 'publishpress-authors'),
-                'type'        => Controls_Manager::TEXT,
-                'default'     => __('Authors List', 'publishpress-authors'),
-                'condition'   => ['show_title' => 'yes'],
             ]
         );
 
@@ -234,13 +122,13 @@ class AuthorsListWidget extends Widget_Base
     }
 
     /**
-     * Get the saved author lists to offer as a select option.
+     * The saved author lists as list_id => title.
      *
      * @return array
      */
-    private function get_saved_author_lists()
+    private function get_author_lists()
     {
-        $options = ['' => __('— Use options below —', 'publishpress-authors')];
+        $lists = [];
 
         try {
             $legacyPlugin = Factory::getLegacyPlugin();
@@ -249,71 +137,64 @@ class AuthorsListWidget extends Widget_Base
         }
 
         if ($legacyPlugin && isset($legacyPlugin->modules->author_list->options->author_list_data)) {
-            $authorLists = (array)$legacyPlugin->modules->author_list->options->author_list_data;
+            $lists = (array)$legacyPlugin->modules->author_list->options->author_list_data;
+        }
 
-            foreach ($authorLists as $listId => $listData) {
-                if (!empty($listData['list_name'])) {
-                    $options[$listId] = $listData['list_name'];
-                }
+        return $lists;
+    }
+
+    /**
+     * Build the select options from the saved author lists.
+     *
+     * @return array
+     */
+    private function get_author_list_options()
+    {
+        $options = [];
+
+        foreach ($this->get_author_lists() as $listId => $listData) {
+            if (is_array($listData) && !empty($listData['title'])) {
+                $options[$listId] = $listData['title'];
             }
+        }
+
+        if (empty($options)) {
+            $options[''] = __('— No author lists found —', 'publishpress-authors');
         }
 
         return $options;
     }
 
     /**
-     * Render the authors list using the plugin shortcode.
+     * Default to the first saved list.
+     *
+     * @return string
+     */
+    private function get_default_list_id()
+    {
+        foreach ($this->get_author_lists() as $listId => $listData) {
+            return (string)$listId;
+        }
+
+        return '';
+    }
+
+    /**
+     * Render the author list through the plugin shortcode.
      */
     protected function render()
     {
         $settings = $this->get_settings_for_display();
 
-        $attributes = [
-            'layout'         => !empty($settings['layout']) ? $settings['layout'] : 'authors_index',
-            'orderby'        => !empty($settings['orderby']) ? $settings['orderby'] : 'name',
-            'order'          => !empty($settings['order']) ? $settings['order'] : 'asc',
-            'limit_per_page' => !empty($settings['limit_per_page']) ? (int)$settings['limit_per_page'] : 20,
-            'show_empty'     => ('yes' === $settings['show_empty']) ? '1' : '0',
-            'search_box'     => ('yes' === $settings['search_box']) ? 'true' : 'false',
-            'show_title'     => ('yes' === $settings['show_title']),
-        ];
-
-        if (!empty($settings['title']) && 'yes' === $settings['show_title']) {
-            $attributes['title'] = $settings['title'];
-        }
-
-        if (!empty($settings['list_id'])) {
-            $attributes = ['list_id' => $settings['list_id'], 'show_title' => ('yes' === $settings['show_title'])];
+        if (empty($settings['list_id'])) {
+            return;
         }
 
         echo do_shortcode(
-            sprintf('[publishpress_authors_list %s]', $this->build_shortcode_string($attributes))
+            sprintf(
+                '[publishpress_authors_list list_id="%s" show_title="false"]',
+                esc_attr($settings['list_id'])
+            )
         );
-    }
-
-    /**
-     * Convert an attribute array into a shortcode attribute string.
-     *
-     * @param array $attributes
-     *
-     * @return string
-     */
-    private function build_shortcode_string($attributes)
-    {
-        $parts = [];
-
-        foreach ($attributes as $key => $value) {
-            if (is_bool($value)) {
-                $value = $value ? 'true' : 'false';
-            }
-
-            if (null === $value || '' === $value) {
-                continue;
-            }
-
-            $parts[] = sprintf('%s="%s"', $key, esc_attr($value));
-        }
-
-        return implode(' ', $parts);
     }
 }

--- a/src/modules/elementor-integration/Modules/AuthorsList/AuthorsListWidget.php
+++ b/src/modules/elementor-integration/Modules/AuthorsList/AuthorsListWidget.php
@@ -1,0 +1,309 @@
+<?php
+/**
+ * @package PublishPress Authors
+ * @author  PublishPress
+ *
+ * Copyright (C) 2018 PublishPress
+ *
+ * This file is part of PublishPress Authors
+ *
+ * PublishPress Authors is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * PublishPress is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with PublishPress.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace PublishPressAuthors\ElementorIntegration\Modules\AuthorsList;
+
+use Elementor\Widget_Base;
+use Elementor\Controls_Manager;
+use MultipleAuthors\Factory;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Class AuthorsListWidget
+ *
+ * An Elementor widget that renders the PublishPress Authors list,
+ * reusing the same layouts as the [publishpress_authors_list] shortcode.
+ *
+ * @package PublishPressAuthors\ElementorIntegration\Modules\AuthorsList
+ */
+class AuthorsListWidget extends Widget_Base
+{
+    /**
+     * @inheritDoc
+     */
+    public function get_name()
+    {
+        return 'publishpress_authors_list';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function get_title()
+    {
+        return __('PublishPress Authors List', 'publishpress-authors');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function get_icon()
+    {
+        return 'eicon-user-circle-o';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function get_categories()
+    {
+        return ['general'];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function get_keywords()
+    {
+        return ['author', 'authors', 'publishpress', 'byline', 'user', 'users'];
+    }
+
+    /**
+     * List of author list layouts available.
+     *
+     * @return array
+     */
+    private function get_layouts()
+    {
+        $layouts = [
+            'authors_index'  => __('Authors Index', 'publishpress-authors'),
+            'authors_recent' => __('Authors Recent', 'publishpress-authors'),
+            'boxed'          => __('Boxed', 'publishpress-authors'),
+            'inline'         => __('Inline', 'publishpress-authors'),
+            'inline_avatars' => __('Inline Avatars', 'publishpress-authors'),
+            'simple_list'    => __('Simple List', 'publishpress-authors'),
+        ];
+
+        return apply_filters('publishpress_authors_elementor_widget_layouts', $layouts);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function register_controls()
+    {
+        // ------------------------------------------
+        // Content section
+        // ------------------------------------------
+        $this->start_controls_section(
+            'section_content',
+            [
+                'label' => __('Authors List', 'publishpress-authors'),
+            ]
+        );
+
+        $this->add_control(
+            'list_id',
+            [
+                'label'       => __('Author List', 'publishpress-authors'),
+                'type'        => Controls_Manager::SELECT,
+                'options'     => $this->get_saved_author_lists(),
+                'description' => __(
+                    'Optionally pick a saved author list created under Authors > Author Lists. Its settings override the options below.',
+                    'publishpress-authors'
+                ),
+            ]
+        );
+
+        $this->add_control(
+            'layout',
+            [
+                'label'   => __('Layout', 'publishpress-authors'),
+                'type'    => Controls_Manager::SELECT,
+                'default' => 'authors_index',
+                'options' => $this->get_layouts(),
+            ]
+        );
+
+        $this->add_control(
+            'orderby',
+            [
+                'label'   => __('Order By', 'publishpress-authors'),
+                'type'    => Controls_Manager::SELECT,
+                'default' => 'name',
+                'options' => [
+                    'name'       => __('Name', 'publishpress-authors'),
+                    'count'      => __('Post Count', 'publishpress-authors'),
+                    'first_name' => __('First Name', 'publishpress-authors'),
+                    'last_name'  => __('Last Name', 'publishpress-authors'),
+                ],
+            ]
+        );
+
+        $this->add_control(
+            'order',
+            [
+                'label'   => __('Order', 'publishpress-authors'),
+                'type'    => Controls_Manager::SELECT,
+                'default' => 'asc',
+                'options' => [
+                    'asc'  => __('Ascending', 'publishpress-authors'),
+                    'desc' => __('Descending', 'publishpress-authors'),
+                ],
+            ]
+        );
+
+        $this->add_control(
+            'limit_per_page',
+            [
+                'label'       => __('Limit Per Page', 'publishpress-authors'),
+                'type'        => Controls_Manager::NUMBER,
+                'min'         => 0,
+                'default'     => 20,
+                'description' => __('Leave 0 to show all authors.', 'publishpress-authors'),
+            ]
+        );
+
+        $this->add_control(
+            'show_empty',
+            [
+                'label'     => __('Show Authors Without Posts', 'publishpress-authors'),
+                'type'      => Controls_Manager::SWITCHER,
+                'label_on'  => __('Yes', 'publishpress-authors'),
+                'label_off' => __('No', 'publishpress-authors'),
+                'default'   => 'yes',
+            ]
+        );
+
+        $this->add_control(
+            'search_box',
+            [
+                'label'     => __('Show Search Box', 'publishpress-authors'),
+                'type'      => Controls_Manager::SWITCHER,
+                'label_on'  => __('Yes', 'publishpress-authors'),
+                'label_off' => __('No', 'publishpress-authors'),
+                'default'   => '',
+            ]
+        );
+
+        $this->add_control(
+            'show_title',
+            [
+                'label'     => __('Show Title', 'publishpress-authors'),
+                'type'      => Controls_Manager::SWITCHER,
+                'label_on'  => __('Yes', 'publishpress-authors'),
+                'label_off' => __('No', 'publishpress-authors'),
+                'default'   => '',
+            ]
+        );
+
+        $this->add_control(
+            'title',
+            [
+                'label'       => __('Title', 'publishpress-authors'),
+                'type'        => Controls_Manager::TEXT,
+                'default'     => __('Authors List', 'publishpress-authors'),
+                'condition'   => ['show_title' => 'yes'],
+            ]
+        );
+
+        $this->end_controls_section();
+    }
+
+    /**
+     * Get the saved author lists to offer as a select option.
+     *
+     * @return array
+     */
+    private function get_saved_author_lists()
+    {
+        $options = ['' => __('— Use options below —', 'publishpress-authors')];
+
+        try {
+            $legacyPlugin = Factory::getLegacyPlugin();
+        } catch (\Exception $e) {
+            $legacyPlugin = null;
+        }
+
+        if ($legacyPlugin && isset($legacyPlugin->modules->author_list->options->author_list_data)) {
+            $authorLists = (array)$legacyPlugin->modules->author_list->options->author_list_data;
+
+            foreach ($authorLists as $listId => $listData) {
+                if (!empty($listData['list_name'])) {
+                    $options[$listId] = $listData['list_name'];
+                }
+            }
+        }
+
+        return $options;
+    }
+
+    /**
+     * Render the authors list using the plugin shortcode.
+     */
+    protected function render()
+    {
+        $settings = $this->get_settings_for_display();
+
+        $attributes = [
+            'layout'         => !empty($settings['layout']) ? $settings['layout'] : 'authors_index',
+            'orderby'        => !empty($settings['orderby']) ? $settings['orderby'] : 'name',
+            'order'          => !empty($settings['order']) ? $settings['order'] : 'asc',
+            'limit_per_page' => !empty($settings['limit_per_page']) ? (int)$settings['limit_per_page'] : 20,
+            'show_empty'     => ('yes' === $settings['show_empty']) ? '1' : '0',
+            'search_box'     => ('yes' === $settings['search_box']) ? 'true' : 'false',
+            'show_title'     => ('yes' === $settings['show_title']),
+        ];
+
+        if (!empty($settings['title']) && 'yes' === $settings['show_title']) {
+            $attributes['title'] = $settings['title'];
+        }
+
+        if (!empty($settings['list_id'])) {
+            $attributes = ['list_id' => $settings['list_id'], 'show_title' => ('yes' === $settings['show_title'])];
+        }
+
+        echo do_shortcode(
+            sprintf('[publishpress_authors_list %s]', $this->build_shortcode_string($attributes))
+        );
+    }
+
+    /**
+     * Convert an attribute array into a shortcode attribute string.
+     *
+     * @param array $attributes
+     *
+     * @return string
+     */
+    private function build_shortcode_string($attributes)
+    {
+        $parts = [];
+
+        foreach ($attributes as $key => $value) {
+            if (is_bool($value)) {
+                $value = $value ? 'true' : 'false';
+            }
+
+            if (null === $value || '' === $value) {
+                continue;
+            }
+
+            $parts[] = sprintf('%s="%s"', $key, esc_attr($value));
+        }
+
+        return implode(' ', $parts);
+    }
+}

--- a/src/modules/elementor-integration/elementor-integration.php
+++ b/src/modules/elementor-integration/elementor-integration.php
@@ -23,6 +23,7 @@
 
 use MultipleAuthors\Classes\Legacy\Module;
 use MultipleAuthors\Factory;
+use PublishPressAuthors\ElementorIntegration\Modules\AuthorsList\AuthorsListWidget;
 use PublishPressAuthors\ElementorIntegration\Modules\Posts\Skins\PostsSkinCards;
 use PublishPressAuthors\ElementorIntegration\Modules\Posts\Skins\PostsSkinClassic;
 use PublishPressAuthors\ElementorIntegration\Modules\Posts\Skins\PostsSkinFullContent;
@@ -88,6 +89,9 @@ if (!class_exists('MA_Elementor_Integration')) {
         {
             add_action('elementor/widget/posts/skins_init', [$this, 'add_posts_skins'], 10, 2);
             add_action('elementor/widget/archive-posts/skins_init', [$this, 'add_archive_posts_skins'], 10, 2);
+            add_action('elementor/widgets/register', [$this, 'register_authors_widgets']);
+            // Legacy Elementor (< 3.5) widget registration hook
+            add_action('elementor/widgets/widgets_registered', [$this, 'register_authors_widgets']);
             add_filter( 'elementor/theme/posts_archive/query_posts/query_vars', [$this, 'filter_posts_archive_query_vars'], 15);
             add_filter( 'elementor/utils/get_the_archive_title', [$this, 'filter_author_archive_title']);
         }
@@ -163,6 +167,28 @@ if (!class_exists('MA_Elementor_Integration')) {
                               ($widget));
             $widget->add_skin(new ArchivePostsSkinClassic($widget));
             $widget->add_skin(new ArchivePostsSkinFullContent($widget));
+        }
+
+        /**
+         * Register the PublishPress Authors Elementor widgets.
+         *
+         * @param \Elementor\Widgets_Manager $widgetsManager
+         */
+        public function register_authors_widgets($widgetsManager)
+        {
+            if (!did_action('elementor/loaded')) {
+                return;
+            }
+
+            require_once __DIR__ . '/Modules/AuthorsList/AuthorsListWidget.php';
+
+            if (method_exists($widgetsManager, 'register')) {
+                // Elementor 3.5+
+                $widgetsManager->register(new AuthorsListWidget());
+            } else {
+                // Legacy Elementor
+                $widgetsManager->register_widget_type(new AuthorsListWidget());
+            }
         }
 
         public function filter_posts_archive_query_vars($query_vars)

--- a/src/modules/elementor-integration/elementor-integration.php
+++ b/src/modules/elementor-integration/elementor-integration.php
@@ -186,6 +186,16 @@ if (!class_exists('MA_Elementor_Integration')) {
                 return;
             }
 
+            if (!wp_style_is('multiple-authors-widget-css', 'registered')) {
+                wp_register_style(
+                    'multiple-authors-widget-css',
+                    PP_AUTHORS_ASSETS_URL . 'css/multiple-authors-widget.css',
+                    [],
+                    defined('PP_AUTHORS_VERSION') ? PP_AUTHORS_VERSION : false,
+                    'all'
+                );
+            }
+
             require_once __DIR__ . '/Modules/AuthorsList/AuthorsListWidget.php';
             require_once __DIR__ . '/Modules/AuthorsBox/AuthorsBoxWidget.php';
 

--- a/src/modules/elementor-integration/elementor-integration.php
+++ b/src/modules/elementor-integration/elementor-integration.php
@@ -23,6 +23,7 @@
 
 use MultipleAuthors\Classes\Legacy\Module;
 use MultipleAuthors\Factory;
+use PublishPressAuthors\ElementorIntegration\Modules\AuthorsBox\AuthorsBoxWidget;
 use PublishPressAuthors\ElementorIntegration\Modules\AuthorsList\AuthorsListWidget;
 use PublishPressAuthors\ElementorIntegration\Modules\Posts\Skins\PostsSkinCards;
 use PublishPressAuthors\ElementorIntegration\Modules\Posts\Skins\PostsSkinClassic;
@@ -186,13 +187,21 @@ if (!class_exists('MA_Elementor_Integration')) {
             }
 
             require_once __DIR__ . '/Modules/AuthorsList/AuthorsListWidget.php';
+            require_once __DIR__ . '/Modules/AuthorsBox/AuthorsBoxWidget.php';
 
-            if (method_exists($widgetsManager, 'register')) {
-                // Elementor 3.5+
-                $widgetsManager->register(new AuthorsListWidget());
-            } else {
-                // Legacy Elementor
-                $widgetsManager->register_widget_type(new AuthorsListWidget());
+            $widgets = [
+                new AuthorsListWidget(),
+                new AuthorsBoxWidget(),
+            ];
+
+            foreach ($widgets as $widget) {
+                if (method_exists($widgetsManager, 'register')) {
+                    // Elementor 3.5+
+                    $widgetsManager->register($widget);
+                } else {
+                    // Legacy Elementor
+                    $widgetsManager->register_widget_type($widget);
+                }
             }
         }
 

--- a/src/modules/elementor-integration/elementor-integration.php
+++ b/src/modules/elementor-integration/elementor-integration.php
@@ -87,13 +87,18 @@ if (!class_exists('MA_Elementor_Integration')) {
          */
         public function init()
         {
-            add_action('elementor/widget/posts/skins_init', [$this, 'add_posts_skins'], 10, 2);
-            add_action('elementor/widget/archive-posts/skins_init', [$this, 'add_archive_posts_skins'], 10, 2);
+            $isPro = defined('ELEMENTOR_PRO_VERSION');
+
+            if ($isPro) {
+                add_action('elementor/widget/posts/skins_init', [$this, 'add_posts_skins'], 10, 2);
+                add_action('elementor/widget/archive-posts/skins_init', [$this, 'add_archive_posts_skins'], 10, 2);
+                add_filter('elementor/theme/posts_archive/query_posts/query_vars', [$this, 'filter_posts_archive_query_vars'], 15);
+                add_filter('elementor/utils/get_the_archive_title', [$this, 'filter_author_archive_title']);
+            }
+
             add_action('elementor/widgets/register', [$this, 'register_authors_widgets']);
             // Legacy Elementor (< 3.5) widget registration hook
             add_action('elementor/widgets/widgets_registered', [$this, 'register_authors_widgets']);
-            add_filter( 'elementor/theme/posts_archive/query_posts/query_vars', [$this, 'filter_posts_archive_query_vars'], 15);
-            add_filter( 'elementor/utils/get_the_archive_title', [$this, 'filter_author_archive_title']);
         }
 
         /**


### PR DESCRIPTION
## Summary

Adds two native Elementor widgets to the existing Elementor integration module, so users can place PublishPress Authors content while building pages in Elementor (including with free Elementor — no Pro required):

**PublishPress Authors Box** — port of the `publishpress-authors/author-boxes-block` Gutenberg block:
- Select control listing saved author boxes from **Authors → Author Boxes**
- Defaults to the first saved box (matching the block's behavior)
- Renders via `[publishpress_authors_box layout="author_boxes_<id>"]`

**PublishPress Authors List** — single select of saved lists from **Authors → Author Lists**:
- Options are read live from the Author Lists editor (e.g. "Author Index List", "Author Recent List")
- Renders via `[publishpress_authors_list list_id="<id>"]` — the list editor stays the single source of truth for layout/columns/search settings

## Details

- `Utils::isElementorInstalled()` now accepts **free Elementor** (`ELEMENTOR_VERSION >= 2.9.3` + `Elementor\\Widget_Base` present). Previously the whole `elementor-integration` module only loaded with Elementor **Pro**, since its original purpose was injecting Pro posts skins. Pro-only behavior (skins, archive filters) is now registered conditionally in `MA_Elementor_Integration::init()` and unchanged for Pro users.
- Both widgets declare `get_style_depends()` → `multiple-authors-widget-css` and the module registers that handle, so layout CSS loads correctly in the Elementor editor (AJAX-rendered previews) and on the frontend — fixes squashed avatar / stray bullet in the editor preview.
- Valid eicons (`eicon-user-circle-o`) used for both widget tiles.
- PHP 7.2 compatible (no `array_key_first()`).
- Widget registration hooks both `elementor/widgets/register` (3.5+) and legacy `widgets_registered`, with method detection.

## Testing

- `php -l` clean on all touched files
- Webpack production build compiles
- Manually tested in Elementor editor with free Elementor: both widgets appear in the panel, render styled previews, and list saved boxes/lists from a real site

## Screenshots

_Author Box widget rendering in the Elementor editor after CSS fix, and Authors List widget offering the saved lists — to be attached_