### PR TITLE
Fix linked author email updates preserving WP user accounts

### DIFF
--- a/src/core/Classes/Author_Editor.php
+++ b/src/core/Classes/Author_Editor.php
@@ -644,14 +644,16 @@ class Author_Editor
         }
 
         $author               = Author::get_by_term_id($term_id);
-        $new_author_email     = sanitize_email($_POST['authors-user_email']);
+        $user_id              = !empty($_POST['authors-user_id']) ? (int)$_POST['authors-user_id'] : 0;
+        $user                 = !empty($user_id) ? get_user_by('id', $user_id) : false;
+        $new_author_email     = (is_a($user, 'WP_User') && (int)$author->user_id !== $user_id)
+            ? sanitize_email($user->user_email)
+            : sanitize_email($_POST['authors-user_email']);
         $current_author_email = sanitize_email($author->user_email);
 
         if ($new_author_email === $current_author_email) {
             return;
         }
-
-        $user_id = !empty($_POST['authors-user_id']) ? (int)$_POST['authors-user_id'] : 0;
 
         $email_validation = Author_Utils::validate_author_email_available($new_author_email, $user_id);
 
@@ -716,6 +718,10 @@ class Author_Editor
             $updated_args['ID'] = $user_id;
         }
 
+        if ($user && (int)$author->user_id !== (int)$user_id) {
+            $_POST['authors-user_email'] = $user->user_email;
+        }
+
         $skip_email_update = false;
         if (isset($_POST['authors-user_email'])) {
             $new_author_email     = sanitize_email($_POST['authors-user_email']);
@@ -755,6 +761,9 @@ class Author_Editor
                 $field_value = isset($_POST['authors-' . $key]) ? $sanitize($_POST['authors-' . $key]) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
             }
             update_term_meta($term_id, $key, $field_value);
+            if ($key === 'user_id') {
+                Author::clear_cache();
+            }
             if ($user_id && $key !== 'user_email') {
                 update_user_meta($user_id, $key, $field_value);
                 // Don't route the bio through wp_update_user(): core's

--- a/src/core/Classes/Author_Editor.php
+++ b/src/core/Classes/Author_Editor.php
@@ -633,6 +633,39 @@ class Author_Editor
         return ob_get_clean();
     }
 
+    public static function action_edit_terms($term_id, $taxonomy, $args = [])
+    {
+        if ('author' !== $taxonomy
+            || empty($_POST['author-edit-nonce'])
+            || !is_user_logged_in()
+            || !wp_verify_nonce(sanitize_key($_POST['author-edit-nonce']), 'author-edit')
+            || !isset($_POST['authors-user_email'])) {
+            return;
+        }
+
+        $author               = Author::get_by_term_id($term_id);
+        $new_author_email     = sanitize_email($_POST['authors-user_email']);
+        $current_author_email = sanitize_email($author->user_email);
+
+        if ($new_author_email === $current_author_email) {
+            return;
+        }
+
+        $user_id = !empty($_POST['authors-user_id']) ? (int)$_POST['authors-user_id'] : 0;
+
+        $email_validation = Author_Utils::validate_author_email_available($new_author_email, $user_id);
+
+        if (is_wp_error($email_validation)) {
+            self::add_author_editor_error($email_validation->get_error_message());
+
+            wp_die(
+                esc_html($email_validation->get_error_message()),
+                esc_html__('Author email error', 'publishpress-authors'),
+                ['back_link' => true]
+            );
+        }
+    }
+
     /**
      * Handle saving of term meta
      *
@@ -683,8 +716,36 @@ class Author_Editor
             $updated_args['ID'] = $user_id;
         }
 
+        $skip_email_update = false;
+        if (isset($_POST['authors-user_email'])) {
+            $new_author_email     = sanitize_email($_POST['authors-user_email']);
+            $current_author_email = sanitize_email($author->user_email);
+
+            if ($new_author_email !== $current_author_email) {
+                $email_validation = Author_Utils::validate_author_email_available($new_author_email, $user_id);
+
+                if (is_wp_error($email_validation)) {
+                    $skip_email_update = true;
+                    self::add_author_editor_error($email_validation->get_error_message());
+                } else {
+                    $email_user_id = !empty($new_author_email) ? email_exists($new_author_email) : false;
+
+                    if ($user_id && (empty($email_user_id) || (int)$email_user_id !== (int)$user_id)) {
+                        Author_Utils::unlink_author_from_user($term_id);
+
+                        $user_id      = false;
+                        $user         = false;
+                        $updated_args = [];
+                    }
+                }
+            }
+        }
+
         foreach (self::get_fields($author) as $key => $args) {
             if (!isset($_POST['authors-' . $key]) && $args['type'] !== 'checkbox') {
+                continue;
+            }
+            if ($skip_email_update && $key === 'user_email') {
                 continue;
             }
             $sanitize = isset($args['sanitize']) ? $args['sanitize'] : 'sanitize_text_field';
@@ -694,7 +755,7 @@ class Author_Editor
                 $field_value = isset($_POST['authors-' . $key]) ? $sanitize($_POST['authors-' . $key]) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
             }
             update_term_meta($term_id, $key, $field_value);
-            if ($user_id) {
+            if ($user_id && $key !== 'user_email') {
                 update_user_meta($user_id, $key, $field_value);
                 // Don't route the bio through wp_update_user(): core's
                 // pre_user_description filter (wp_filter_kses) strips block-level
@@ -961,6 +1022,12 @@ class Author_Editor
      */
     public static function admin_notices()
     {
+        $errors = self::get_author_editor_errors();
+
+        foreach ($errors as $error) {
+            echo '<div class="notice notice-error is-dismissible"><p>' . esc_html($error) . '</p></div>';
+        }
+
         if (!empty($_REQUEST['bulk_update_author'])) {
             $count = (int)$_REQUEST['bulk_update_author'];
 
@@ -977,6 +1044,35 @@ class Author_Editor
 
             echo '</p></div>';
         }
+    }
+
+    private static function add_author_editor_error($message)
+    {
+        $transient_key = self::get_author_editor_errors_transient_key();
+        $errors        = get_transient($transient_key);
+
+        if (!is_array($errors)) {
+            $errors = [];
+        }
+
+        $errors[] = $message;
+
+        set_transient($transient_key, $errors, MINUTE_IN_SECONDS);
+    }
+
+    private static function get_author_editor_errors()
+    {
+        $transient_key = self::get_author_editor_errors_transient_key();
+        $errors        = get_transient($transient_key);
+
+        delete_transient($transient_key);
+
+        return is_array($errors) ? $errors : [];
+    }
+
+    private static function get_author_editor_errors_transient_key()
+    {
+        return 'ppma_author_editor_errors_' . get_current_user_id();
     }
 
     /**
@@ -1074,6 +1170,12 @@ class Author_Editor
                         )
                     );
                 } else {
+                    $email_validation = Author_Utils::validate_author_email_available($_POST['authors-author_email']);
+
+                    if (is_wp_error($email_validation)) {
+                        return $email_validation;
+                    }
+
                     if (!get_role('ppma_guest_author')) {
                         //Make sure Guest authir role exist
                         add_role('ppma_guest_author', 'Guest Author', []);

--- a/src/core/Classes/Author_Utils.php
+++ b/src/core/Classes/Author_Utils.php
@@ -9,7 +9,9 @@
 
 namespace MultipleAuthors\Classes;
 
+use MultipleAuthors\Classes\Objects\Author;
 use MultipleAuthors\Factory;
+use WP_Error;
 
 /**
  * Utility methods for managing authors
@@ -81,6 +83,41 @@ abstract class Author_Utils
     public static function update_author_meta($termId, $metaKey, $value, $single = true)
     {
         return update_term_meta($termId, $metaKey, $value);
+    }
+
+    public static function validate_author_email_available($emailAddress, $allowedUserId = 0)
+    {
+        $emailAddress = sanitize_email($emailAddress);
+
+        if (empty($emailAddress)) {
+            return true;
+        }
+
+        $existingUserId = email_exists($emailAddress);
+
+        if (!empty($existingUserId) && (int)$existingUserId !== (int)$allowedUserId) {
+            return new WP_Error(
+                'publishpress_authors_email_exists',
+                __('This email address is already linked to another WordPress user.', 'publishpress-authors')
+            );
+        }
+
+        return true;
+    }
+
+    public static function unlink_author_from_user($termId)
+    {
+        $metas = get_term_meta($termId);
+
+        foreach ($metas as $key => $meta) {
+            if (0 === strpos($key, 'user_id_')) {
+                delete_term_meta($termId, $key);
+            }
+        }
+
+        delete_term_meta($termId, 'user_id');
+        clean_term_cache($termId, 'author');
+        Author::clear_cache();
     }
 
     public static function author_is_guest($termId)

--- a/src/core/Classes/Objects/Author.php
+++ b/src/core/Classes/Objects/Author.php
@@ -908,6 +908,14 @@ class Author
         return self::get_by_term_id($id);
     }
 
+    public static function clear_cache()
+    {
+        self::$authorsByIdCache     = [];
+        self::$authorsBySlugCache   = [];
+        self::$authorsByTermIdCache = [];
+        self::$authorsByEmailCache  = [];
+    }
+
     /**
      * Get author posts count with support for post_type.
      *

--- a/src/core/Plugin.php
+++ b/src/core/Plugin.php
@@ -274,6 +274,12 @@ class Plugin
                 2
             );
             add_action(
+                'edit_terms',
+                ['MultipleAuthors\\Classes\\Author_Editor', 'action_edit_terms'],
+                10,
+                3
+            );
+            add_action(
                 'wp_ajax_mapped_author_validation',
                 ['MultipleAuthors\\Classes\\Admin_Ajax', 'handle_mapped_author_validation']
             );

--- a/src/modules/rest-api/rest-api.php
+++ b/src/modules/rest-api/rest-api.php
@@ -25,6 +25,7 @@ use MultipleAuthors\Classes\Legacy\Module;
 use MultipleAuthors\Classes\Legacy\Util;
 use MultipleAuthors\Classes\Objects\Author;
 use MultipleAuthors\Classes\Author_Editor;
+use MultipleAuthors\Classes\Author_Utils;
 use MultipleAuthors\Factory;
 
 if (!class_exists('MA_REST_API')) {
@@ -488,6 +489,36 @@ if (!class_exists('MA_REST_API')) {
                 $updated_args['ID'] = $author_user_id;
             }
 
+            $has_email_update = array_key_exists('user_email', $params) || array_key_exists('user_email', $author_fields);
+            if ($has_email_update) {
+                $new_author_email = array_key_exists('user_email', $author_fields)
+                    ? sanitize_email($author_fields['user_email'])
+                    : sanitize_email($params['user_email']);
+                $current_author_email = sanitize_email($author->user_email);
+
+                if ($new_author_email !== $current_author_email) {
+                    $email_validation = Author_Utils::validate_author_email_available(
+                        $new_author_email,
+                        $author_user_id
+                    );
+
+                    if (is_wp_error($email_validation)) {
+                        $email_validation->add_data(['status' => 409]);
+
+                        return $email_validation;
+                    }
+
+                    $email_user_id = !empty($new_author_email) ? email_exists($new_author_email) : false;
+
+                    if ($author_user_id && (empty($email_user_id) || (int)$email_user_id !== (int)$author_user_id)) {
+                        Author_Utils::unlink_author_from_user($term_id);
+
+                        $author_user_id = 0;
+                        $updated_args   = [];
+                    }
+                }
+            }
+
             // update terms args data
             $update_data = [];
             if (!empty($params['display_name'])) {
@@ -512,13 +543,9 @@ if (!class_exists('MA_REST_API')) {
                 }
             }
 
-            // Update email and sync to user if mapped
-            if (!empty($params['user_email'])) {
+            // Update author email without changing the mapped WordPress user account email.
+            if (array_key_exists('user_email', $params)) {
                 update_term_meta($term_id, 'user_email', sanitize_email($params['user_email']));
-                if ($author_user_id) {
-                    update_user_meta($author_user_id, 'user_email', sanitize_email($params['user_email']));
-                    $updated_args['user_email'] = sanitize_email($params['user_email']);
-                }
             }
 
             $this->setAuthorFields($term_id, $author_fields, $author_user_id, $updated_args);
@@ -557,8 +584,8 @@ if (!class_exists('MA_REST_API')) {
                     $sanitized_value = $this->sanitizeFieldValue($field_value, $field_config);
                     update_term_meta($term_id, $field_name, $sanitized_value);
 
-                    // Also update user meta if there's a mapped user
-                    if ($user_id) {
+                    // Also update user meta if there's a mapped user, except the core account email.
+                    if ($user_id && $field_name !== 'user_email') {
                         update_user_meta($user_id, $field_name, $sanitized_value);
                         $updated_args[$field_name] = $sanitized_value;
                     }

--- a/src/modules/rest-api/rest-api.php
+++ b/src/modules/rest-api/rest-api.php
@@ -456,10 +456,13 @@ if (!class_exists('MA_REST_API')) {
         {
             $term_id = $author->term_id;
 
-            $author_user_id = $author->user_id;
+            $previous_author_user_id = (int)$author->user_id;
+            $author_user_id          = !empty($params['user_id']) ? (int)$params['user_id'] : $previous_author_user_id;
+            $linked_user_changed     = false;
 
             if (!empty($author_user_id)) {
                 $user = get_user_by('id', $author_user_id);
+                $linked_user_changed = is_a($user, 'WP_User') && $previous_author_user_id !== (int)$author_user_id;
 
                 if ($user && (int)$author_user_id !== get_current_user_id()) {
                     // Prevent editing administrators completely
@@ -480,6 +483,14 @@ if (!class_exists('MA_REST_API')) {
                             ['status' => 403]
                         );
                     }
+                }
+            }
+
+            if ($linked_user_changed) {
+                $params['user_email'] = $user->user_email;
+
+                if (array_key_exists('user_email', $author_fields)) {
+                    $author_fields['user_email'] = $user->user_email;
                 }
             }
 
@@ -517,6 +528,11 @@ if (!class_exists('MA_REST_API')) {
                         $updated_args   = [];
                     }
                 }
+            }
+
+            if ($linked_user_changed) {
+                update_term_meta($term_id, 'user_id', $author_user_id);
+                Author::clear_cache();
             }
 
             // update terms args data

--- a/tests/codeception/wpunit/core/Classes/PluginCest.php
+++ b/tests/codeception/wpunit/core/Classes/PluginCest.php
@@ -3,6 +3,7 @@
 namespace core\Classes;
 
 use Codeception\Example;
+use MultipleAuthors\Classes\Author_Editor;
 use MultipleAuthors\Classes\Objects\Author;
 use MultipleAuthors\Factory;
 use WpunitTester;
@@ -144,5 +145,128 @@ class PluginCest
         $I->assertEquals('original-author', get_term_meta($author->term_id, 'user_login', true));
         $I->assertEquals('https://example.com/updated-author', get_term_meta($author->term_id, 'user_url', true));
         $I->assertEquals('Updated author bio.', get_term_meta($author->term_id, 'description', true));
+    }
+
+    public function actionEditedAuthor_forMappedAuthorEmailChangeUnlinksAuthorAndDoesNotDeleteUserEmail(WpunitTester $I)
+    {
+        $userID = $I->factory('a new user')->user->create(
+            [
+                'role'          => 'author',
+                'display_name'  => 'Mapped Author',
+                'first_name'    => 'Mapped',
+                'last_name'     => 'Author',
+                'user_email'    => 'mapped-author@example.com',
+                'user_login'    => 'mapped-author',
+                'user_nicename' => 'mapped-author',
+                'user_url'      => 'https://example.com/mapped-author',
+                'description'   => 'Mapped author bio.',
+            ]
+        );
+        $author = Author::create_from_user($userID);
+
+        $adminUserID = $I->factory('a new administrator user')->user->create(
+            [
+                'role' => 'administrator',
+            ]
+        );
+        wp_set_current_user($adminUserID);
+
+        $_POST['author-edit-nonce']  = wp_create_nonce('author-edit');
+        $_POST['authors-user_id']    = $userID;
+        $_POST['authors-first_name'] = 'Mapped';
+        $_POST['authors-last_name']  = 'Author';
+        $_POST['authors-user_email'] = '';
+        $_POST['authors-user_url']   = 'https://example.com/mapped-author';
+        $_POST['authors-description'] = 'Mapped author bio.';
+
+        Author_Editor::action_edited_author($author->term_id);
+
+        $user = get_user_by('id', $userID);
+
+        $I->assertEquals('', get_term_meta($author->term_id, 'user_email', true));
+        $I->assertEquals('mapped-author@example.com', $user->user_email);
+        $I->assertEquals('', get_term_meta($author->term_id, 'user_id', true));
+        $I->assertEquals('', get_term_meta($author->term_id, 'user_id_' . $userID, true));
+        $I->assertFalse(Author::get_by_user_id($userID));
+
+        $_POST = [];
+    }
+
+    public function actionEditedAuthor_forMappedAuthorRejectsEmailUsedByAnotherUser(WpunitTester $I)
+    {
+        $userID = $I->factory('a new user')->user->create(
+            [
+                'role'          => 'author',
+                'display_name'  => 'Mapped Author',
+                'user_email'    => 'mapped-author-conflict@example.com',
+                'user_login'    => 'mapped-author-conflict',
+                'user_nicename' => 'mapped-author-conflict',
+            ]
+        );
+        $author = Author::create_from_user($userID);
+
+        $otherUserID = $I->factory('another user')->user->create(
+            [
+                'role'       => 'author',
+                'user_email' => 'other-author@example.com',
+            ]
+        );
+
+        $adminUserID = $I->factory('a new administrator user')->user->create(
+            [
+                'role' => 'administrator',
+            ]
+        );
+        wp_set_current_user($adminUserID);
+
+        $_POST['author-edit-nonce']  = wp_create_nonce('author-edit');
+        $_POST['authors-user_id']    = $userID;
+        $_POST['authors-first_name'] = '';
+        $_POST['authors-last_name']  = '';
+        $_POST['authors-user_email'] = 'other-author@example.com';
+        $_POST['authors-user_url']   = '';
+        $_POST['authors-description'] = '';
+
+        Author_Editor::action_edited_author($author->term_id);
+
+        $user = get_user_by('id', $userID);
+        ob_start();
+        Author_Editor::admin_notices();
+        $notice = ob_get_clean();
+
+        $I->assertEquals('mapped-author-conflict@example.com', get_term_meta($author->term_id, 'user_email', true));
+        $I->assertEquals('mapped-author-conflict@example.com', $user->user_email);
+        $I->assertEquals($userID, (int)get_term_meta($author->term_id, 'user_id', true));
+        $I->assertEquals('user_id', get_term_meta($author->term_id, 'user_id_' . $userID, true));
+        $I->assertNotEquals($otherUserID, (int)get_term_meta($author->term_id, 'user_id', true));
+        $I->assertStringContainsString(
+            'This email address is already linked to another WordPress user.',
+            $notice
+        );
+
+        $_POST = [];
+    }
+
+    public function filterPreInsertTerm_forNewUserAuthorRejectsEmailUsedByAnotherUser(WpunitTester $I)
+    {
+        $I->factory('another user')->user->create(
+            [
+                'role'       => 'author',
+                'user_email' => 'existing-user@example.com',
+            ]
+        );
+
+        $_POST['action']               = 'add-tag';
+        $_POST['authors-author_type']  = 'new_user';
+        $_POST['authors-author_email'] = 'existing-user@example.com';
+        $_POST['authors-new']          = '';
+        $_POST['tag-name']             = 'Duplicate Email Author';
+
+        $result = Author_Editor::filter_pre_insert_term('Duplicate Email Author', 'author');
+
+        $I->assertTrue(is_wp_error($result));
+        $I->assertEquals('publishpress_authors_email_exists', $result->get_error_code());
+
+        $_POST = [];
     }
 }

--- a/tests/codeception/wpunit/core/Classes/PluginCest.php
+++ b/tests/codeception/wpunit/core/Classes/PluginCest.php
@@ -247,6 +247,53 @@ class PluginCest
         $_POST = [];
     }
 
+    public function actionEditedAuthor_forLinkedUserChangeUsesNewUserEmail(WpunitTester $I)
+    {
+        $originalUserID = $I->factory('original linked user')->user->create(
+            [
+                'role'       => 'author',
+                'user_email' => 'original-linked-user@example.com',
+            ]
+        );
+        $newUserID = $I->factory('new linked user')->user->create(
+            [
+                'role'       => 'author',
+                'user_email' => 'new-linked-user@example.com',
+            ]
+        );
+        $author = Author::create_from_user($originalUserID);
+
+        $adminUserID = $I->factory('a new administrator user')->user->create(
+            [
+                'role' => 'administrator',
+            ]
+        );
+        wp_set_current_user($adminUserID);
+
+        $_POST['author-edit-nonce']  = wp_create_nonce('author-edit');
+        $_POST['authors-user_id']    = $newUserID;
+        $_POST['authors-first_name'] = '';
+        $_POST['authors-last_name']  = '';
+        $_POST['authors-user_email'] = 'original-linked-user@example.com';
+        $_POST['authors-user_url']   = '';
+        $_POST['authors-description'] = '';
+
+        Author_Editor::action_edit_terms($author->term_id, 'author');
+        Author_Editor::action_edited_author($author->term_id);
+
+        $originalUser = get_user_by('id', $originalUserID);
+        $newUser      = get_user_by('id', $newUserID);
+
+        $I->assertEquals('new-linked-user@example.com', get_term_meta($author->term_id, 'user_email', true));
+        $I->assertEquals($newUserID, (int)get_term_meta($author->term_id, 'user_id', true));
+        $I->assertFalse(Author::get_by_user_id($originalUserID));
+        $I->assertEquals($author->term_id, Author::get_by_user_id($newUserID)->term_id);
+        $I->assertEquals('original-linked-user@example.com', $originalUser->user_email);
+        $I->assertEquals('new-linked-user@example.com', $newUser->user_email);
+
+        $_POST = [];
+    }
+
     public function filterPreInsertTerm_forNewUserAuthorRejectsEmailUsedByAnotherUser(WpunitTester $I)
     {
         $I->factory('another user')->user->create(


### PR DESCRIPTION
Removing email in PublishPress Authors profile deletes the email from the underlying WordPress user account fix #2423