### PR TITLE
Improve accessibility labels in author forms

### DIFF
--- a/src/core/Authors_Widget.php
+++ b/src/core/Authors_Widget.php
@@ -465,18 +465,22 @@ class Authors_Widget extends WP_Widget
         $search_box_html = '';
         if (isset($instance['search_box']) && $instance['search_box']) {
             $current_url = remove_query_arg(['ppma_page', 'paged', 'seach_query', 'search_field'], $_SERVER['REQUEST_URI']);
+            $search_input_id  = wp_unique_id('authors-search-input-');
+            $search_filter_id = wp_unique_id('authors-search-filter-');
 
             $search_box_html .= '<div class="pp-multiple-authors-searchbox searchbox">';
-            $search_box_html .= '<form action="' . esc_url($current_url) . '" method="GET">';
-            $search_box_html .= '<input class="widefat" id="authors-search-input" name="seach_query" type="search" value="'. esc_attr($search_query) .'" placeholder="'. esc_attr($search_placeholder) .'">';
+            $search_box_html .= '<form action="' . esc_url($current_url) . '" method="GET" role="search">';
+            $search_box_html .= '<label class="screen-reader-text" for="' . esc_attr($search_input_id) . '">' . esc_html__('Search authors', 'publishpress-authors') . '</label>';
+            $search_box_html .= '<input class="widefat" id="' . esc_attr($search_input_id) . '" name="seach_query" type="search" value="'. esc_attr($search_query) .'" placeholder="'. esc_attr($search_placeholder) .'">';
             if ($filter_fields) {
-                $search_box_html .= '<select id="authors-search-filter" name="search_field">';
+                $search_box_html .= '<label class="screen-reader-text" for="' . esc_attr($search_filter_id) . '">' . esc_html__('Search authors by', 'publishpress-authors') . '</label>';
+                $search_box_html .= '<select id="' . esc_attr($search_filter_id) . '" name="search_field">';
                 foreach ($filter_fields as $option => $label) :
                     $search_box_html .= '<option value="'. esc_attr($option) .'" '. selected($option, $selected_option, false) .'> '. esc_html($label) .' </option>';
                 endforeach;
                 $search_box_html .= '</select>';
             }
-            $search_box_html .= '<input type="submit" class="button search-submit" id="" name="submit" value="'. esc_attr($search_submit) .'"/>';
+            $search_box_html .= '<input type="submit" class="button search-submit" name="submit" value="'. esc_attr($search_submit) .'"/>';
             $search_box_html .= '</form>';
             $search_box_html .= '</div>';
         }

--- a/src/core/Classes/Author_Editor.php
+++ b/src/core/Classes/Author_Editor.php
@@ -569,12 +569,14 @@ class Author_Editor
                     </div>
                 <?php elseif ('textarea' === $args['type']) : ?>
                     <textarea
-                            name="<?php echo esc_attr($key); ?>"><?php echo esc_textarea($args['value']); ?></textarea>
+                            name="<?php echo esc_attr($key); ?>"
+                            id="<?php echo esc_attr($key); ?>"><?php echo esc_textarea($args['value']); ?></textarea>
                 <?php
                 elseif ('ajax_user_select' === $args['type']) :
                     $user = !empty($args['value']) ? get_user_by('id', $args['value']) : false;
                     ?>
                     <select data-nonce="<?php echo esc_attr(wp_create_nonce('authors-user-search')); ?>"
+                            id="<?php echo esc_attr($key); ?>"
                             placeholder="<?php esc_attr_e('Select a user', 'publishpress-authors'); ?>"
                             class="authors-select2-user-select" name="<?php echo esc_attr($key); ?>" style="width: 95%">
                         <option></option>

--- a/src/core/Classes/Post_Editor.php
+++ b/src/core/Classes/Post_Editor.php
@@ -451,6 +451,7 @@ class Post_Editor
         }
         ?>
         <?php if (current_user_can(get_taxonomy('author')->cap->assign_terms)) : ?>
+            <label class="screen-reader-text" for="publishpress-authors-author-select"><?php esc_html_e('Search for an author', 'publishpress-authors'); ?></label>
             <select data-nonce="<?php
             echo esc_attr(wp_create_nonce('authors-search')); ?>"
                     id="publishpress-authors-author-select"
@@ -646,8 +647,10 @@ class Post_Editor
                 }
             }
             ?>
+            <label class="screen-reader-text" for="publishpress-authors-author-filter"><?php esc_html_e('Filter posts by author', 'publishpress-authors'); ?></label>
             <select data-nonce="<?php
                 echo esc_attr(wp_create_nonce('authors-user-search')); ?>"
+                    id="publishpress-authors-author-filter"
                     class="authors-select2 authors-user-slug-search"
                     data-placeholder="<?php
                     esc_attr_e('All Authors', 'publishpress-authors'); ?>" style="width: 150px"

--- a/src/modules/author-categories/author-categories.php
+++ b/src/modules/author-categories/author-categories.php
@@ -701,9 +701,9 @@ class MA_Author_Categories extends Module
                                     <select
                                         style="width: 95%;"
                                         class="authors-select2-default-select"
+                                        id="category-post-types"
                                         <?php if ($proActive) : ?>
                                         name="category-post-types[]"
-                                        id="category-post-types"
                                         <?php endif; ?>
                                         data-placeholder="<?php esc_attr_e('Select Post Type...', 'publishpress-authors'); ?>"
                                         multiple


### PR DESCRIPTION
## Summary
- add explicit labels to frontend author search controls
- add labels to post editor author selectors
- associate Author Editor and category post type controls with their existing labels
- generate unique search control IDs when multiple widgets are rendered

## Validation
- php -l passed for all changed PHP files
- git diff --check passed
- PHPCS was not run because vendor/bin/phpcs is not present in this checkout