### PR TITLE
Add accessible image alternatives for authors

### DIFF
--- a/src/core/Classes/Objects/Author.php
+++ b/src/core/Classes/Objects/Author.php
@@ -794,6 +794,9 @@ class Author
             $imageId = attachment_url_to_postid($urls['url']);
             $alt = get_post_meta( $imageId, '_wp_attachment_image_alt', true );
         }
+        if (empty($alt)) {
+            $alt = $this->display_name;
+        }
 
         // Build the HTML tag.
         $avatar = sprintf(

--- a/src/functions/template-tags.php
+++ b/src/functions/template-tags.php
@@ -1015,6 +1015,7 @@ if (!function_exists('publishpress_authors_get_all_authors')) {
                         $post_index++;
                         if ($post_index === 1) {
                             $featured_image = PP_AUTHORS_ASSETS_URL . 'img/no-image.jpeg';
+                            $featured_image_alt = '';
                             if (has_post_thumbnail($author_recent_post)) {
                                 if (!empty($featured_image_size)) {
                                     $featured_image_data = wp_get_attachment_image_src(get_post_thumbnail_id($author_recent_post), $featured_image_size);
@@ -1024,16 +1025,22 @@ if (!function_exists('publishpress_authors_get_all_authors')) {
                                 if ($featured_image_data && is_array($featured_image_data)) {
                                     $featured_image = $featured_image_data[0];
                                 }
+                                $featured_image_alt = get_post_meta(get_post_thumbnail_id($author_recent_post), '_wp_attachment_image_alt', true);
+                                if (empty($featured_image_alt)) {
+                                    $featured_image_alt = get_the_title($author_recent_post);
+                                }
                             }
 
                         } else {
                             $featured_image = false;
+                            $featured_image_alt = '';
                         }
                         $author_recent[$author_recent_post] = [
                             'ID'              => $author_recent_post,
                             'post_title'      => html_entity_decode(get_the_title($author_recent_post)),
                             'permalink'       => get_the_permalink($author_recent_post),
-                            'featuired_image' => $featured_image
+                            'featuired_image' => $featured_image,
+                            'featured_image_alt' => $featured_image_alt,
 
                         ];
                     }

--- a/src/templates/parts/author-pages-grid.php
+++ b/src/templates/parts/author-pages-grid.php
@@ -82,6 +82,9 @@ if ($author_post_custom_height > 0) {
                             $featured_image = $image_data[0];
                             $featured_image_id = get_post_thumbnail_id();
                             $featured_image_alt = get_post_meta($featured_image_id, '_wp_attachment_image_alt', true);
+                            if (empty($featured_image_alt)) {
+                                $featured_image_alt = get_the_title();
+                            }
                         }
                     }
                     $post_categories  = ($show_post_category) ? get_the_category_list(', ') : false;

--- a/src/templates/parts/author-pages-list.php
+++ b/src/templates/parts/author-pages-list.php
@@ -82,6 +82,9 @@ if ($author_post_custom_height > 0) {
                             $featured_image = $image_data[0];
                             $featured_image_id = get_post_thumbnail_id();
                             $featured_image_alt = get_post_meta($featured_image_id, '_wp_attachment_image_alt', true);
+                            if (empty($featured_image_alt)) {
+                                $featured_image_alt = get_the_title();
+                            }
                         }
                     }
                     $post_categories  = ($show_post_category) ? get_the_category_list(', ') : false;

--- a/src/views/authors_recent.html.php
+++ b/src/views/authors_recent.html.php
@@ -24,8 +24,8 @@
                             <?php foreach ($result['recent_posts'] as $post_id => $post) : ?>
                                 <?php if ($post['featuired_image']) : ?>
                                     <div class="ppma-col-5 featured-image-col post-<?php echo esc_attr($post_id); ?>">
-                                        <a href="<?php echo esc_url($post['permalink']); ?>">
-                                            <img src="<?php echo esc_url($post['featuired_image']); ?>">
+                                        <a href="<?php echo esc_url($post['permalink']); ?>" aria-label="<?php echo esc_attr(sprintf(__('View %s', 'publishpress-authors'), $post['post_title'])); ?>">
+                                            <img src="<?php echo esc_url($post['featuired_image']); ?>" alt="<?php echo esc_attr($post['featured_image_alt']); ?>">
                                         </a>
                                     </div>
 

--- a/src/views/footer-base.html.php
+++ b/src/views/footer-base.html.php
@@ -33,7 +33,7 @@ $rating_star .= '<span class="dashicons dashicons-star-filled"></span>';
     </nav>
     <div class="ppma-pressshack-logo">
         <a href="//publishpress.com" target="_blank" rel="noopener noreferrer">
-            <img src="<?php echo esc_attr($context['plugin_url']); ?>src/assets/img/publishpress-logo.png">
+            <img src="<?php echo esc_attr($context['plugin_url']); ?>src/assets/img/publishpress-logo.png" alt="<?php echo esc_attr($context['plugin_name']); ?>">
         </a>
     </div>
 </footer>


### PR DESCRIPTION
## Summary
- add post-title fallbacks for featured-image alt text
- name recent-post image links and provide alt text
- add alt text to the admin footer logo
- ensure custom author avatars have a meaningful fallback alt

## Validation
- php -l passed for all changed PHP files
- git diff --check passed
- PHPCS was not run because vendor/bin/phpcs is not present in this checkout