### PR TITLE
Improve keyboard access to author controls

### DIFF
--- a/src/assets/css/multiple-authors.css
+++ b/src/assets/css/multiple-authors.css
@@ -189,6 +189,11 @@ ul.authors-list.authors-current-user-can-assign li .author-remove {
     -webkit-transform: translateY(-50%);
     transform: translateY(-50%);
     cursor: pointer;
+    border: 0;
+    padding: 0;
+    background: transparent;
+    color: inherit;
+    font: inherit;
 }
 
 ul.authors-list.authors-current-user-can-assign li .author-remove .dashicons {
@@ -371,6 +376,10 @@ form#edittag tr.form-field #slug {
     right: 30px;
     top: 15px;
     color: #655997;
+    border: 0;
+    padding: 0;
+    background: transparent;
+    font: inherit;
 }
 
 .ppma-settings-shortcodes-shortcode .ppma-copy-clipboard span {

--- a/src/assets/js/multiple-authors.js
+++ b/src/assets/js/multiple-authors.js
@@ -1155,6 +1155,7 @@ jQuery(document).ready(function ($) {
      * Settings shortcode copy to clipboard
      */
     $(document).on('click', '.ppma-copy-clipboard', function (event) {
+        var copy_button = event.target.closest('.ppma-copy-clipboard');
         //get the text field
         var shortcode_input = event.target.closest('.ppma-settings-shortcodes-shortcode').querySelector('.shortcode-field');
         //select the text field
@@ -1163,21 +1164,20 @@ jQuery(document).ready(function ($) {
         //copy the text inside the text field
         navigator.clipboard.writeText(shortcode_input.value);
         //update tooltip notification
-        event.target.closest('.ppma-settings-shortcodes-shortcode')
-            .querySelector('.ppma-copy-clipboard span')
-            .innerHTML = event.target.closest('.ppma-settings-shortcodes-shortcode').querySelector('.ppma-copy-clipboard span')
-                .getAttribute('data-copied');
+        var copy_message = copy_button.querySelector('span');
+        copy_message.innerHTML = copy_message.getAttribute('data-copied');
+        copy_button.setAttribute('aria-label', copy_message.getAttribute('data-copied'));
     });
 
     /**
      * Copy to clipboard copied text change
      */
     $(document).on('mouseleave', '.ppma-copy-clipboard', function (event) {
+        var copy_button = event.target.closest('.ppma-copy-clipboard');
         //update tooltip text
-        event.target.closest('.ppma-settings-shortcodes-shortcode')
-            .querySelector('.ppma-copy-clipboard span')
-            .innerHTML = event.target.closest('.ppma-settings-shortcodes-shortcode').querySelector('.ppma-copy-clipboard span')
-                .getAttribute('data-copy');
+        var copy_message = copy_button.querySelector('span');
+        copy_message.innerHTML = copy_message.getAttribute('data-copy');
+        copy_button.setAttribute('aria-label', copy_message.getAttribute('data-copy'));
     });
 
     /**

--- a/src/core/Classes/Post_Editor.php
+++ b/src/core/Classes/Post_Editor.php
@@ -690,9 +690,9 @@ class Post_Editor
         echo esc_attr($args['category_id']); ?>" data-term-id="<?php
         echo esc_attr($args['term']); ?>" data-is-guest="<?php
         echo esc_attr($args['is_guest']); ?>" class="ui-sortable-handle publishpress-authors-author">
-            <span class="author-remove">
-                <span class="dashicons dashicons-no-alt"></span>
-            </span>
+            <button type="button" class="author-remove" aria-label="<?php echo esc_attr(sprintf(esc_html__('Remove %s', 'publishpress-authors'), $args['display_name'])); ?>">
+                <span class="dashicons dashicons-no-alt" aria-hidden="true"></span>
+            </button>
             <?php
             if (!empty($args['avatar'])) : ?>
                 <?php

--- a/src/core/Classes/Utils.php
+++ b/src/core/Classes/Utils.php
@@ -1320,7 +1320,9 @@ class Utils
         </div>
         <a
             href="#TB_inline?&width=<?php echo esc_attr($width); ?>&height=<?php echo esc_attr($height); ?>&inlineId=<?php echo esc_attr($button_id); ?>"
-            class="<?php echo esc_attr($button_class); ?> thickbox">
+            class="<?php echo esc_attr($button_class); ?> thickbox"
+            aria-hidden="true"
+            tabindex="-1">
         </a>
         <?php
     }

--- a/src/core/Plugin.php
+++ b/src/core/Plugin.php
@@ -794,7 +794,7 @@ class Plugin
         }
 
         $columns['posts_count'] = sprintf(
-            '%s <i class="dashicons dashicons-info-outline" title="%s"></i>',
+            '%s <i class="dashicons dashicons-info-outline" aria-hidden="true" title="%s"></i>',
             __('Posts', 'publishpress-authors'),
             sprintf(
                 __('Published posts of the following post types: %s', 'publishpress-authors'),

--- a/src/modules/author-boxes/assets/css/author-boxes-editor.css
+++ b/src/modules/author-boxes/assets/css/author-boxes-editor.css
@@ -297,6 +297,10 @@
 .ppma-boxes-shortcodes-wrap .shortcode-entries .delete-shortcode {
     color: #f54d4d;
     cursor: pointer;
+    border: 0;
+    padding: 0;
+    background: transparent;
+    font: inherit;
 }
 
 .ppma-boxes-editor-tab-content.ppma-profile_fields-tab.profile_header .input {
@@ -407,6 +411,11 @@
     color: #655997;
     margin-bottom: 10px;
     text-align: right;
+    width: 100%;
+    border: 0;
+    padding: 0;
+    background: transparent;
+    font: inherit;
 }
 
 .ppma-editor-field-reorder-btn .dashicons {

--- a/src/modules/author-boxes/assets/js/author-boxes-editor.js
+++ b/src/modules/author-boxes/assets/js/author-boxes-editor.js
@@ -1453,7 +1453,7 @@
             var new_entry = '<tr class="shortcode-entry">';
             new_entry += '<td class="shortcode">' + escAttr(shortcode) + '</td>';
             new_entry += '<td class="position">' + position.charAt(0).toUpperCase() + position.slice(1) + '</td>';
-            new_entry += '<td class="action"><input name="shortcodes[shortcode][]" id="shortcodes-shortcode" type="hidden" value="' + escAttr(shortcode) + '"><input name="shortcodes[position][]" id="shortcodes-position" type="hidden" value="' + position + '"><span class="delete-shortcode">' + $('.ppma-boxes-shortcodes-wrap .shortcode-entries .add-new-shortcode').attr('data-delete') +'</span></td>';
+            new_entry += '<td class="action"><input name="shortcodes[shortcode][]" id="shortcodes-shortcode" type="hidden" value="' + escAttr(shortcode) + '"><input name="shortcodes[position][]" id="shortcodes-position" type="hidden" value="' + position + '"><button type="button" class="delete-shortcode">' + $('.ppma-boxes-shortcodes-wrap .shortcode-entries .add-new-shortcode').attr('data-delete') +'</button></td>';
             new_entry += '</tr>';
             $('.ppma-boxes-shortcodes-wrap .shortcode-form .shortcodes-shortcode-input').val('');
             $('.ppma-boxes-shortcodes-wrap .shortcode-form').after(new_entry);

--- a/src/modules/author-boxes/author-boxes.php
+++ b/src/modules/author-boxes/author-boxes.php
@@ -2775,10 +2775,10 @@ class MA_Author_Boxes extends Module
                                         </select>
                                         </td>
                                         <td class="shortcode-field">
-                                            <div class="add-new-shortcode button"
+                                            <button type="button" class="add-new-shortcode button"
                                                 data-delete="<?php echo esc_attr__('Delete', 'publishpress-authors'); ?>">
                                                 <?php echo esc_html__('Add', 'publishpress-authors'); ?>
-                                            </div>
+                                            </button>
                                         </td>
                                     </tr>
                                     <?php if (is_array($shortcodes_data) && !empty($shortcodes_data)) : ?>
@@ -2804,9 +2804,9 @@ class MA_Author_Boxes extends Module
                                                         type="hidden"
                                                         value="<?php echo esc_attr($shortcode_position); ?>"
                                                     />
-                                                    <span class="delete-shortcode">
+                                                    <button type="button" class="delete-shortcode">
                                                         <?php echo esc_html__('Delete', 'publishpress-authors'); ?>
-                                                    </span>
+                                                    </button>
                                                 </td>
                                             </tr>
                                         <?php endforeach; ?>
@@ -2949,10 +2949,10 @@ class MA_Author_Boxes extends Module
                     $additional_class .= ' profile-header-' .$args['tab_name'];
                     ?>
                     <?php if ((int)$args['index'] === 1) : ?>
-                        <div class="ppma-editor-field-reorder-btn">
+                        <button type="button" class="ppma-editor-field-reorder-btn">
                             <span class="dashicons dashicons-admin-generic"></span>
                             <?php esc_html_e('Reorder Fields', 'publishpress-authors'); ?>
-                        </div>
+                        </button>
                         <?php
 
                         $profile_fields   = self::get_profile_fields($args['post_id']);

--- a/src/modules/author-categories/classes/AuthorCategoriesTable.php
+++ b/src/modules/author-categories/classes/AuthorCategoriesTable.php
@@ -92,7 +92,7 @@ class AuthorCategoriesTable extends \WP_List_Table
     function get_columns()
     {
         $columns = [
-            'cb' => '<input type="checkbox" />',
+            'cb' => '<input type="checkbox" aria-label="' . esc_attr__('Select all author categories', 'publishpress-authors') . '" />',
             'category_name' => esc_html__('Name', 'publishpress-authors'),
             'plural_name' => esc_html__('Plural Name', 'publishpress-authors'),
             'post_types' => esc_html__('Post Types', 'publishpress-authors'),
@@ -129,7 +129,12 @@ class AuthorCategoriesTable extends \WP_List_Table
      */
     function column_cb($item)
     {
-        return sprintf('<input type="checkbox" name="%1$s[]" value="%2$s" />', 'author_categories', $item['id']);
+        return sprintf(
+            '<input type="checkbox" name="%1$s[]" value="%2$s" aria-label="%3$s" />',
+            'author_categories',
+            $item['id'],
+            esc_attr(sprintf(esc_html__('Select %s', 'publishpress-authors'), $item['category_name']))
+        );
     }
 
     /**

--- a/src/modules/author-list/author-list.php
+++ b/src/modules/author-list/author-list.php
@@ -1358,10 +1358,10 @@ class MA_Author_List extends Module
                                         <div id="minor-publishing"></div>
                                         <div id="major-publishing-actions">
                                             <div>
-                                                <label style="display: none;"><strong><?php esc_html_e('Dynamic Shortcode', 'publishpress-authors'); ?>:</strong></label>
-                                                <textarea name="author_list[dynamic_shortcode]" class="shortcode-textarea dynamic" readonly="">[publishpress_authors_list list_id="<?php echo esc_attr($shortcode_id); ?>"]</textarea>
-                                                <label style="display: none;"><strong><?php esc_html_e('Static Shortcode', 'publishpress-authors'); ?>:</strong></label>
-                                                <textarea style="display: none;" name="author_list[static_shortcode]" class="shortcode-textarea static" readonly=""><?php echo esc_html($static_shortcode) ?></textarea>
+                                                <label class="screen-reader-text" for="author-list-dynamic-shortcode"><strong><?php esc_html_e('Dynamic Shortcode', 'publishpress-authors'); ?>:</strong></label>
+                                                <textarea id="author-list-dynamic-shortcode" name="author_list[dynamic_shortcode]" class="shortcode-textarea dynamic" readonly="">[publishpress_authors_list list_id="<?php echo esc_attr($shortcode_id); ?>"]</textarea>
+                                                <label class="screen-reader-text" for="author-list-static-shortcode"><strong><?php esc_html_e('Static Shortcode', 'publishpress-authors'); ?>:</strong></label>
+                                                <textarea id="author-list-static-shortcode" style="display: none;" name="author_list[static_shortcode]" class="shortcode-textarea static" readonly=""><?php echo esc_html($static_shortcode) ?></textarea>
                                             </div>
                                             <div class="clear"></div>
                                         </div>

--- a/src/modules/author-list/classes/AuthorListTable.php
+++ b/src/modules/author-list/classes/AuthorListTable.php
@@ -333,7 +333,7 @@ class AuthorListTable extends \WP_List_Table
         if ($this->list_view === 'active') {
             $actions = [
                 'edit'   => sprintf(
-                    '<a href="%s">%s</a>',
+                    '<a href="%s" aria-label="%s">%s</a>',
                     add_query_arg(
                         [
                             'page'              => 'ppma-author-list',
@@ -341,10 +341,11 @@ class AuthorListTable extends \WP_List_Table
                         ],
                         admin_url('admin.php')
                     ),
+                    esc_attr(sprintf(esc_html__('Edit %s', 'publishpress-authors'), $item['title'])),
                     esc_html__('Edit', 'publishpress-authors')
                 ),
                 'delete' => sprintf(
-                    '<a href="%s" class="delete-author-list">%s</a>',
+                    '<a href="%s" class="delete-author-list" aria-label="%s">%s</a>',
                     add_query_arg([
                             'page'              => 'ppma-author-list',
                             'action'            => 'ppma-trash-author-list',
@@ -353,13 +354,14 @@ class AuthorListTable extends \WP_List_Table
                         ],
                         admin_url('admin.php')
                     ),
+                    esc_attr(sprintf(esc_html__('Move %s to Trash', 'publishpress-authors'), $item['title'])),
                     esc_html__('Trash', 'publishpress-authors')
                 ),
             ];
         } else {
             $actions = [
                 'edit'   => sprintf(
-                    '<a href="%s">%s</a>',
+                    '<a href="%s" aria-label="%s">%s</a>',
                     add_query_arg(
                         [
                             'page'              => 'ppma-author-list',
@@ -369,10 +371,11 @@ class AuthorListTable extends \WP_List_Table
                         ],
                         admin_url('admin.php')
                     ),
+                    esc_attr(sprintf(esc_html__('Restore %s', 'publishpress-authors'), $item['title'])),
                     esc_html__('Restore', 'publishpress-authors')
                 ),
                 'delete' => sprintf(
-                    '<a href="%s" class="delete-author-list">%s</a>',
+                    '<a href="%s" class="delete-author-list" aria-label="%s">%s</a>',
                     add_query_arg([
                             'page'              => 'ppma-author-list',
                             'action'            => 'ppma-delete-author-list',
@@ -381,6 +384,7 @@ class AuthorListTable extends \WP_List_Table
                         ],
                         admin_url('admin.php')
                     ),
+                    esc_attr(sprintf(esc_html__('Delete %s permanently', 'publishpress-authors'), $item['title'])),
                     esc_html__('Delete Permanently', 'publishpress-authors')
                 ),
             ];
@@ -446,8 +450,10 @@ class AuthorListTable extends \WP_List_Table
      */
     protected function column_dynamic_shortcode($item)
     {
+        $input_id = 'author-list-shortcode-' . (int) $item['ID'];
 
-        return '<input readonly type="text" value=\'' . $item['dynamic_shortcode'] . '\' />';
+        return '<label class="screen-reader-text" for="' . esc_attr($input_id) . '">' . esc_html__('Dynamic shortcode', 'publishpress-authors') . '</label>'
+            . '<input id="' . esc_attr($input_id) . '" readonly type="text" value="' . esc_attr($item['dynamic_shortcode']) . '" />';
     }
 
     /**
@@ -459,8 +465,10 @@ class AuthorListTable extends \WP_List_Table
      */
     protected function column_static_shortcode($item)
     {
+        $textarea_id = 'author-list-static-shortcode-' . (int) $item['ID'];
 
-        return '<textarea style="resize:none; width: 99%;" readonly>' . $item['static_shortcode'] . '</textarea>';
+        return '<label class="screen-reader-text" for="' . esc_attr($textarea_id) . '">' . esc_html__('Static shortcode', 'publishpress-authors') . '</label>'
+            . '<textarea id="' . esc_attr($textarea_id) . '" style="resize:none; width: 99%;" readonly>' . esc_textarea($item['static_shortcode']) . '</textarea>';
     }
 
     /**

--- a/src/modules/multiple-authors/multiple-authors.php
+++ b/src/modules/multiple-authors/multiple-authors.php
@@ -1915,14 +1915,16 @@ if (!class_exists('MA_Multiple_Authors')) {
                         class="shortcode-field"
                         type="text"
                         value="<?php echo esc_attr($option['shortcode']); ?>"
+                        aria-label="<?php esc_attr_e('Shortcode', 'publishpress-authors'); ?>"
                         readonly
                         />
-                    <span class="ppma-copy-clipboard dashicons dashicons-admin-page">
+                    <button type="button" class="ppma-copy-clipboard dashicons dashicons-admin-page"
+                        aria-label="<?php esc_attr_e('Copy shortcode to clipboard', 'publishpress-authors'); ?>">
                         <span data-copied="<?php echo esc_attr__('Copied!', 'publishpress-authors'); ?>"
                             data-copy="<?php echo esc_attr__('Click To Copy!', 'publishpress-authors'); ?>">
                             <?php echo esc_html__('Click To Copy!', 'publishpress-authors'); ?>
                         </span>
-                    </span>
+                    </button>
                     </div>
             <?php endforeach; ?>
 


### PR DESCRIPTION
## Summary
- turn author removal, shortcode, and reorder controls into keyboard-accessible buttons
- label shortcode fields and author-category selection checkboxes
- give author-list row actions contextual accessible names
- hide the programmatic modal trigger from the accessibility tree
- preserve copy-to-clipboard status for screen readers

## Validation
- php -l passed for all changed PHP files
- node --check passed for changed JavaScript files
- git diff --check passed with CRLF-aware whitespace validation
- PHPCS was not run because vendor/bin/phpcs is not present in this checkout