### PR TITLE
Fix author category SQL preparation warnings

### DIFF
--- a/src/functions/template-tags.php
+++ b/src/functions/template-tags.php
@@ -2012,6 +2012,8 @@ if (!function_exists('get_ppma_author_categories')) {
             'slug',
             'category_order',
             'category_status',
+            'created_at',
+            'meta_data',
         ];
         $orderby_column  = in_array($args['orderby'], $allowed_orderby, true) ? $args['orderby'] : 'category_order';
         $order           = strtoupper($args['order']) === 'DESC' ? 'DESC' : 'ASC';

--- a/src/functions/template-tags.php
+++ b/src/functions/template-tags.php
@@ -2005,7 +2005,17 @@ if (!function_exists('get_ppma_author_categories')) {
         $category_name   = sanitize_text_field($args['category_name']);
         $plural_name     = sanitize_text_field($args['plural_name']);
         $search          = sanitize_text_field($args['search']);
-        $orderby         = sanitize_sql_orderby($args['orderby'] . ' ' . strtoupper($args['order']));
+        $allowed_orderby = [
+            'id',
+            'category_name',
+            'plural_name',
+            'slug',
+            'category_order',
+            'category_status',
+        ];
+        $orderby_column  = in_array($args['orderby'], $allowed_orderby, true) ? $args['orderby'] : 'category_order';
+        $order           = strtoupper($args['order']) === 'DESC' ? 'DESC' : 'ASC';
+        $orderby         = $orderby_column . ' ' . $order;
         $category_status = sanitize_text_field($args['category_status']);
         $count_only      = boolval($args['count_only']);
         $no_cache        = boolval($args['no_cache']);
@@ -2039,6 +2049,7 @@ if (!function_exists('get_ppma_author_categories')) {
             $category_results = [];
             if ($field_search) {
                 // Single result
+                // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table, column, and order fragments are internal whitelisted values.
                 $query = $wpdb->prepare(
                     "SELECT * FROM {$table_name}
                     WHERE {$table_name}.{$field_search} = %s
@@ -2046,16 +2057,21 @@ if (!function_exists('get_ppma_author_categories')) {
                     LIMIT 1",
                     $field_value
                 );
+                // phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+                // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared above with whitelisted SQL fragments.
                 $category_row = $wpdb->get_row($query, ARRAY_A);
 
                 if ($category_row) {
                     // Fetch all meta for this ID
+                    // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is generated internally.
                     $meta_query = $wpdb->prepare(
                         "SELECT meta_key, meta_value
                         FROM {$meta_table_name}
                         WHERE category_id = %d",
                         $category_row['id']
                     );
+                    // phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+                    // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared above with an internal table name.
                     $metas = $wpdb->get_results($meta_query, ARRAY_A);
 
                     // Merge meta into main row
@@ -2073,8 +2089,10 @@ if (!function_exists('get_ppma_author_categories')) {
                 $offset = ($paged - 1) * $limit;
 
                 if ($count_only) {
+                    // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is generated internally.
                     $query = "SELECT COUNT(*) FROM {$table_name} WHERE 1=1";
                 } else {
+                    // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is generated internally.
                     $query = "SELECT * FROM {$table_name} WHERE 1=1";
                 }
 
@@ -2087,6 +2105,7 @@ if (!function_exists('get_ppma_author_categories')) {
                         $prepare_values[] = '%"' . $wpdb->esc_like($post_type) . '"%';
                     }
 
+                    // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared -- Table name and LIKE placeholders are generated internally.
                     $subquery = $wpdb->prepare(
                         "SELECT DISTINCT category_id
                         FROM {$meta_table_name}
@@ -2094,11 +2113,14 @@ if (!function_exists('get_ppma_author_categories')) {
                         AND (" . implode(' OR ', $like_conditions) . ")",
                         ...$prepare_values
                     );
+                    // phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared
 
+                    // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name and subquery are internally built.
                     $query .= " AND {$table_name}.id IN ({$subquery})";
                 } elseif (!empty($post_type_and_empty)) {
                     $post_type = $post_type_and_empty;
 
+                    // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is generated internally.
                     $subquery = $wpdb->prepare(
                         "SELECT DISTINCT category_id
                         FROM {$meta_table_name}
@@ -2106,7 +2128,9 @@ if (!function_exists('get_ppma_author_categories')) {
                         AND (meta_value LIKE %s OR meta_value IS NULL OR meta_value = '')",
                         '%"' . $wpdb->esc_like($post_type) . '"%'
                     );
+                    // phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
+                    // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names and subquery are internally built.
                     $query .= " AND ({$table_name}.id IN ({$subquery}) OR {$table_name}.id NOT IN (
                         SELECT DISTINCT category_id
                         FROM {$meta_table_name}
@@ -2117,11 +2141,12 @@ if (!function_exists('get_ppma_author_categories')) {
                 }
 
                 if (!empty($search)) {
+                    $search_like = '%' . $wpdb->esc_like($search) . '%';
                     $query .= $wpdb->prepare(
-                        " AND (slug LIKE '%%%s%%' OR category_name LIKE '%%%s%%' OR plural_name LIKE '%%%s%%')",
-                        $search,
-                        $search,
-                        $search
+                        " AND (slug LIKE %s OR category_name LIKE %s OR plural_name LIKE %s)",
+                        $search_like,
+                        $search_like,
+                        $search_like
                     );
                 }
 
@@ -2133,12 +2158,16 @@ if (!function_exists('get_ppma_author_categories')) {
                 }
 
                 if ($count_only) {
+                    // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query fragments above are prepared or internal whitelisted SQL fragments.
                     return $wpdb->get_var($query);
                 }
 
+                // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared -- ORDER BY fragment is whitelisted above and query contains prepared fragments.
                 $query .= " ORDER BY {$orderby} LIMIT %d OFFSET %d";
                 $query = $wpdb->prepare($query, $limit, $offset);
+                // phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared
 
+                // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared above after adding limit and offset placeholders.
                 $categories = $wpdb->get_results($query, ARRAY_A);
                 if (!$categories) {
                     return [];
@@ -2147,12 +2176,15 @@ if (!function_exists('get_ppma_author_categories')) {
                 // Query metas
                 $ids = wp_list_pluck($categories, 'id');
                 $placeholders = implode(',', array_fill(0, count($ids), '%d'));
+                // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name and placeholders are generated internally from integer IDs.
                 $meta_query = $wpdb->prepare(
                     "SELECT category_id, meta_key, meta_value
                     FROM {$meta_table_name}
                     WHERE category_id IN ($placeholders)",
                     ...$ids
                 );
+                // phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+                // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared above with generated integer placeholders.
                 $metas = $wpdb->get_results($meta_query, ARRAY_A);
 
                 // Merge metas into main categories
@@ -2272,8 +2304,7 @@ if (!function_exists('get_ppma_author_relations')) {
             $relationships_table    = $wpdb->prefix . 'ppma_author_relationships';
             $categories_table       = $wpdb->prefix . 'ppma_author_categories';
 
-            $sql = "SELECT * FROM $relationships_table WHERE 1=1";
-
+            // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table names are generated internally.
             $sql = "SELECT r.*, c.category_name, c.plural_name FROM $relationships_table r LEFT JOIN $categories_table c ON r.category_id = c.id  WHERE 1=1";
 
             if ($post_id !== '') {
@@ -2286,6 +2317,7 @@ if (!function_exists('get_ppma_author_relations')) {
 
             $sql .= ' ORDER BY r.id ASC';
 
+            // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query fragments above are prepared or internal table names.
             $results = $wpdb->get_results($sql, ARRAY_A);
 
             wp_cache_set($cache_key, $results, 'author_categories_relation_cache', 3600);

--- a/src/modules/author-categories/author-categories.php
+++ b/src/modules/author-categories/author-categories.php
@@ -514,10 +514,8 @@ class MA_Author_Categories extends Module
         // Check if the slug already exists
         if (isset($insert_args['slug'])) {
             $slug = $insert_args['slug'];
-            $existing_id = $wpdb->get_var($wpdb->prepare(
-                "SELECT id FROM $table_name WHERE slug = %s",
-                $slug
-            ));
+            // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is generated internally by AuthorCategoriesSchema.
+            $existing_id = $wpdb->get_var($wpdb->prepare("SELECT id FROM {$table_name} WHERE slug = %s", $slug));
 
             if ($existing_id) {
                 return get_ppma_author_categories(['id' => $existing_id]);
@@ -590,13 +588,19 @@ class MA_Author_Categories extends Module
         $table_name     = AuthorCategoriesSchema::metaTableName();
 
         if (empty($meta_value)) {
-            $result = $wpdb->query(
-                $wpdb->prepare(
-                    "DELETE FROM {$table_name} WHERE meta_key = %s AND category_id = %d",
-                    $meta_key, $category_id
-                )
+            $result = $wpdb->delete(
+                $table_name,
+                [
+                    'meta_key'    => $meta_key,
+                    'category_id' => (int) $category_id,
+                ],
+                [
+                    '%s',
+                    '%d',
+                ]
             );
         } else {
+            // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is generated internally by AuthorCategoriesSchema.
             $meta_ids = $wpdb->get_col($wpdb->prepare("SELECT meta_id FROM $table_name WHERE meta_key = %s AND category_id = %d", $meta_key, $category_id));
 
             if (empty($meta_ids)) {

--- a/src/modules/author-categories/classes/AuthorCategoriesSchema.php
+++ b/src/modules/author-categories/classes/AuthorCategoriesSchema.php
@@ -63,7 +63,9 @@ class AuthorCategoriesSchema
     {
         global $wpdb;
 
-        return $wpdb->get_var("SHOW TABLES LIKE '{$table_name}'") === $table_name;
+        return $wpdb->get_var(
+            $wpdb->prepare('SHOW TABLES LIKE %s', $wpdb->esc_like($table_name))
+        ) === $table_name;
     }
 
     /**

--- a/src/modules/author-categories/classes/AuthorCategoriesTable.php
+++ b/src/modules/author-categories/classes/AuthorCategoriesTable.php
@@ -225,18 +225,16 @@ class AuthorCategoriesTable extends \WP_List_Table
         $table_name = AuthorCategoriesSchema::tableName();
         $meta_table_name = AuthorCategoriesSchema::metaTableName();
 
-        $delete = $wpdb->query(
-            $wpdb->prepare(
-                "DELETE FROM {$table_name} WHERE id = %d",
-                $category_id
-            )
+        $delete = $wpdb->delete(
+            $table_name,
+            ['id' => (int) $category_id],
+            ['%d']
         );
 
-        $wpdb->query(
-            $wpdb->prepare(
-                "DELETE FROM {$meta_table_name} WHERE category_id = %d",
-                $category_id
-            )
+        $wpdb->delete(
+            $meta_table_name,
+            ['category_id' => (int) $category_id],
+            ['%d']
         );
 
         return $delete;

--- a/tests/codeception/wpunit/core/functions/get_ppma_author_categoriesCest.php
+++ b/tests/codeception/wpunit/core/functions/get_ppma_author_categoriesCest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace core\functions;
+
+use MultipleAuthorCategories\AuthorCategoriesSchema;
+use WpunitTester;
+
+class get_ppma_author_categoriesCest
+{
+    public function testGetAuthorCategoriesCanOrderByPreviouslySupportedColumns(WpunitTester $I)
+    {
+        global $wpdb;
+
+        AuthorCategoriesSchema::createTableIfNotExists();
+        AuthorCategoriesSchema::createMetaTableIfNotExists();
+
+        $tableName = AuthorCategoriesSchema::tableName();
+        $categories = [
+            [
+                'category_name' => 'Older category',
+                'plural_name'   => 'Older categories',
+                'slug'          => 'older-category',
+                'created_at'    => '2024-01-01 00:00:00',
+            ],
+            [
+                'category_name' => 'Newer category',
+                'plural_name'   => 'Newer categories',
+                'slug'          => 'newer-category',
+                'created_at'    => '2025-01-01 00:00:00',
+            ],
+        ];
+
+        foreach ($categories as $category) {
+            $wpdb->insert(
+                $tableName,
+                array_merge(
+                    $category,
+                    [
+                        'category_order'  => 0,
+                        'category_status' => 7,
+                        'meta_data'       => $category['slug'],
+                    ]
+                )
+            );
+        }
+
+        $results = get_ppma_author_categories(
+            [
+                'limit'           => 2,
+                'orderby'         => 'created_at',
+                'order'           => 'DESC',
+                'category_status' => 7,
+                'no_cache'        => true,
+            ]
+        );
+
+        $I->assertSame(
+            ['newer-category', 'older-category'],
+            wp_list_pluck($results, 'slug')
+        );
+
+        $results = get_ppma_author_categories(
+            [
+                'limit'           => 2,
+                'orderby'         => 'meta_data',
+                'order'           => 'DESC',
+                'category_status' => 7,
+                'no_cache'        => true,
+            ]
+        );
+
+        $I->assertSame(
+            ['older-category', 'newer-category'],
+            wp_list_pluck($results, 'slug')
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Replace raw/interpolated author category table checks and deletes with prepared or structured wpdb calls
- Whitelist author category ordering and escape LIKE search values
- Add narrow PHPCS explanations for internally generated table names on WordPress 5.5-compatible SQL

## Tests
- `vendor/bin/phpcs --standard=phpcs.xml --sniffs=WordPress.DB.PreparedSQL,WordPress.DB.PreparedSQLPlaceholders --report=summary src/modules/author-categories/author-categories.php src/modules/author-categories/classes/AuthorCategoriesSchema.php src/modules/author-categories/classes/AuthorCategoriesTable.php`
- `php -l src/modules/author-categories/classes/AuthorCategoriesSchema.php && php -l src/modules/author-categories/classes/AuthorCategoriesTable.php && php -l src/modules/author-categories/author-categories.php && php -l src/functions/template-tags.php`
- Combined validation branch: targeted SQL PHPCS across all screenshot files returned 0 errors