### PR TITLE
Fix core SQL preparation warnings

### DIFF
--- a/src/core/Classes/Installer.php
+++ b/src/core/Classes/Installer.php
@@ -170,9 +170,13 @@ class Installer
             return [];
         }
 
-        $parsedArgs['posts_per_page'] = max(1, (int)$parsedArgs['posts_per_page']);
+        $parsedArgs['posts_per_page'] = (int)$parsedArgs['posts_per_page'];
+        $parsedArgs['paged']          = (int)$parsedArgs['paged'];
 
-        $parsedArgs['paged'] = max(1, (int)$parsedArgs['paged']);
+        if ($parsedArgs['posts_per_page'] < 1 || $parsedArgs['paged'] < 1) {
+            return [];
+        }
+
         $parsedArgs['paged'] = $parsedArgs['paged'] * $parsedArgs['posts_per_page'] - $parsedArgs['posts_per_page'];
         $post_type_placeholders = implode(', ', array_fill(0, count($parsedArgs['post_type']), '%s'));
         $query_args = array_merge(
@@ -291,22 +295,43 @@ class Installer
             return [];
         }
 
-        $parsedArgs['order'] = strtoupper($parsedArgs['order']) === 'DESC' ? 'DESC' : 'ASC';
+        $parsedArgs['order'] = strtoupper(trim($parsedArgs['order'])) === 'DESC' ? 'DESC' : 'ASC';
 
         $allowed_orderby = [
-            'ID',
-            'post_author',
-            'post_date',
-            'post_name',
-            'post_status',
-            'post_title',
-            'post_type',
+            'id'                    => 'ID',
+            'post_author'           => 'post_author',
+            'post_date'             => 'post_date',
+            'post_date_gmt'         => 'post_date_gmt',
+            'post_content'          => 'post_content',
+            'post_title'            => 'post_title',
+            'post_excerpt'          => 'post_excerpt',
+            'post_status'           => 'post_status',
+            'comment_status'        => 'comment_status',
+            'ping_status'           => 'ping_status',
+            'post_password'         => 'post_password',
+            'post_name'             => 'post_name',
+            'to_ping'               => 'to_ping',
+            'pinged'                => 'pinged',
+            'post_modified'         => 'post_modified',
+            'post_modified_gmt'     => 'post_modified_gmt',
+            'post_content_filtered' => 'post_content_filtered',
+            'post_parent'           => 'post_parent',
+            'guid'                  => 'guid',
+            'menu_order'            => 'menu_order',
+            'post_type'             => 'post_type',
+            'post_mime_type'        => 'post_mime_type',
+            'comment_count'         => 'comment_count',
         ];
-        $parsedArgs['orderby'] = in_array($parsedArgs['orderby'], $allowed_orderby, true) ? $parsedArgs['orderby'] : 'ID';
+        $orderby_key = strtolower(trim($parsedArgs['orderby']));
+        $parsedArgs['orderby'] = $allowed_orderby[$orderby_key] ?? 'ID';
 
-        $parsedArgs['posts_per_page'] = max(1, (int)$parsedArgs['posts_per_page']);
+        $parsedArgs['posts_per_page'] = (int)$parsedArgs['posts_per_page'];
+        $parsedArgs['paged']          = (int)$parsedArgs['paged'];
 
-        $parsedArgs['paged'] = max(1, (int)$parsedArgs['paged']);
+        if ($parsedArgs['posts_per_page'] < 1 || $parsedArgs['paged'] < 1) {
+            return [];
+        }
+
         $parsedArgs['paged'] = $parsedArgs['paged'] * $parsedArgs['posts_per_page'] - $parsedArgs['posts_per_page'];
         $post_type_placeholders = implode(', ', array_fill(0, count($parsedArgs['post_type']), '%s'));
         $query_args = array_merge(

--- a/src/core/Classes/Installer.php
+++ b/src/core/Classes/Installer.php
@@ -161,19 +161,33 @@ class Installer
 
 
         if (!is_array($parsedArgs['post_type'])) {
-            $parsedArgs['post_type'] = [esc_sql($parsedArgs['post_type'])];
+            $parsedArgs['post_type'] = [$parsedArgs['post_type']];
         }
 
-        $parsedArgs['post_type'] = array_map('esc_sql', $parsedArgs['post_type']);
+        $parsedArgs['post_type'] = array_values(array_filter(array_map('sanitize_key', $parsedArgs['post_type'])));
 
-        $parsedArgs['posts_per_page'] = (int)$parsedArgs['posts_per_page'];
+        if (empty($parsedArgs['post_type'])) {
+            return [];
+        }
 
-        $parsedArgs['paged'] = (int)$parsedArgs['paged'];
+        $parsedArgs['posts_per_page'] = max(1, (int)$parsedArgs['posts_per_page']);
+
+        $parsedArgs['paged'] = max(1, (int)$parsedArgs['paged']);
         $parsedArgs['paged'] = $parsedArgs['paged'] * $parsedArgs['posts_per_page'] - $parsedArgs['posts_per_page'];
+        $post_type_placeholders = implode(', ', array_fill(0, count($parsedArgs['post_type']), '%s'));
+        $query_args = array_merge(
+            $parsedArgs['post_type'],
+            [
+                $parsedArgs['paged'],
+                $parsedArgs['posts_per_page'],
+            ]
+        );
 
         return wp_list_pluck(
-            $wpdb->get_results( // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-                "
+            $wpdb->get_results(
+                // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Post type placeholders are generated from a sanitized array.
+                $wpdb->prepare(
+                    "
                 SELECT DISTINCT
                     p.post_author AS ID
                 FROM
@@ -188,10 +202,13 @@ class Installer
                             AND tt.taxonomy = 'author'
                     )
                     AND p.post_author <> 0
-                    AND p.post_type IN ('" . implode('\',\'', $parsedArgs['post_type']) . "')
+                    AND p.post_type IN ($post_type_placeholders)
                     AND p.post_status NOT IN ('trash')
-                LIMIT {$parsedArgs['paged']}, {$parsedArgs['posts_per_page']}
-                "
+                LIMIT %d, %d
+                ",
+                    $query_args
+                )
+                // phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
             ),
             'ID'
         );
@@ -265,22 +282,45 @@ class Installer
 
 
         if (!is_array($parsedArgs['post_type'])) {
-            $parsedArgs['post_type'] = [esc_sql($parsedArgs['post_type'])];
+            $parsedArgs['post_type'] = [$parsedArgs['post_type']];
         }
 
-        $parsedArgs['post_type'] = array_map('esc_sql', $parsedArgs['post_type']);
+        $parsedArgs['post_type'] = array_values(array_filter(array_map('sanitize_key', $parsedArgs['post_type'])));
+
+        if (empty($parsedArgs['post_type'])) {
+            return [];
+        }
 
         $parsedArgs['order'] = strtoupper($parsedArgs['order']) === 'DESC' ? 'DESC' : 'ASC';
 
-        $parsedArgs['orderby'] = esc_sql($parsedArgs['orderby']);
+        $allowed_orderby = [
+            'ID',
+            'post_author',
+            'post_date',
+            'post_name',
+            'post_status',
+            'post_title',
+            'post_type',
+        ];
+        $parsedArgs['orderby'] = in_array($parsedArgs['orderby'], $allowed_orderby, true) ? $parsedArgs['orderby'] : 'ID';
 
-        $parsedArgs['posts_per_page'] = (int)$parsedArgs['posts_per_page'];
+        $parsedArgs['posts_per_page'] = max(1, (int)$parsedArgs['posts_per_page']);
 
-        $parsedArgs['paged'] = (int)$parsedArgs['paged'];
+        $parsedArgs['paged'] = max(1, (int)$parsedArgs['paged']);
         $parsedArgs['paged'] = $parsedArgs['paged'] * $parsedArgs['posts_per_page'] - $parsedArgs['posts_per_page'];
+        $post_type_placeholders = implode(', ', array_fill(0, count($parsedArgs['post_type']), '%s'));
+        $query_args = array_merge(
+            $parsedArgs['post_type'],
+            [
+                $parsedArgs['paged'],
+                $parsedArgs['posts_per_page'],
+            ]
+        );
 
-        return $wpdb->get_results( // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-            "
+        return $wpdb->get_results(
+            // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Post type placeholders and order fragments are sanitized or whitelisted above.
+            $wpdb->prepare(
+                "
             SELECT
                 p.*
             FROM
@@ -295,12 +335,15 @@ class Installer
                         tt.taxonomy = 'author') AS str ON (str.object_id = p.ID
                 )
             WHERE
-                p.post_type IN ('" . implode('\',\'', $parsedArgs['post_type']) . "')
+                p.post_type IN ($post_type_placeholders)
                 AND p.post_status NOT IN('trash')
                 AND str.term_taxonomy_id IS NULL
             ORDER BY {$parsedArgs['orderby']} {$parsedArgs['order']}
-            LIMIT {$parsedArgs['paged']}, {$parsedArgs['posts_per_page']}
-            "
+            LIMIT %d, %d
+            ",
+                $query_args
+            )
+            // phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
         );
     }
 

--- a/src/core/Classes/Objects/Author.php
+++ b/src/core/Classes/Objects/Author.php
@@ -995,6 +995,7 @@ class Author
              */
             $query    = apply_filters('ppma_author_posts_count_query', $query, $term_id, $post_type);
 
+            // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is built from prepared fragments, then passed through the existing filter for backward compatibility.
             $counts = (int)$wpdb->get_var($query);
 
             /**

--- a/src/core/Classes/Utils.php
+++ b/src/core/Classes/Utils.php
@@ -257,10 +257,13 @@ class Utils
 
         if (!$allow_multiple_categories) {
             $existing_relations = $wpdb->get_results(
+                // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is generated internally.
                 $wpdb->prepare(
                     "SELECT category_id, author_term_id FROM {$table_name} WHERE post_id = %d ORDER BY id ASC",
                     $post_id
-                ),
+                )
+                // phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+                ,
                 ARRAY_A
             );
 
@@ -359,10 +362,12 @@ class Utils
         $query_args   = array_merge([$post_id], $authors);
 
         $wpdb->query(
+            // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name and placeholders are generated internally from integer IDs.
             $wpdb->prepare(
                 "DELETE FROM {$table_name} WHERE post_id = %d AND author_term_id NOT IN ({$placeholders})",
                 $query_args
             )
+            // phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
         );
 
         do_action('publishpress_authors_flush_cache_for_post', $post_id);
@@ -1417,17 +1422,26 @@ class Utils
         global $wpdb;
 
         if ( is_array( $post_type ) ) {
-            $post_type           = esc_sql( $post_type );
-            $post_type_in_string = "'" . implode( "','", $post_type ) . "'";
-            $sql                 = $wpdb->prepare(
+            $post_type = array_values(array_filter(array_map('sanitize_key', $post_type)));
+
+            if (empty($post_type)) {
+                return null;
+            }
+
+            $post_type_placeholders = implode(', ', array_fill(0, count($post_type), '%s'));
+            $query_args             = array_merge([$page_title], $post_type);
+
+            // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Post type placeholders are generated from a sanitized array.
+            $sql                    = $wpdb->prepare(
                 "
                 SELECT ID
                 FROM $wpdb->posts
                 WHERE post_title = %s
-                AND post_type IN ($post_type_in_string)
+                AND post_type IN ($post_type_placeholders)
             ",
-                $page_title
+                $query_args
             );
+            // phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
         } else {
             $sql = $wpdb->prepare(
                 "
@@ -1441,6 +1455,7 @@ class Utils
             );
         }
 
+        // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Query is prepared above.
         $page = $wpdb->get_var( $sql );
 
         if ( $page ) {

--- a/src/core/Plugin.php
+++ b/src/core/Plugin.php
@@ -1161,16 +1161,21 @@ class Plugin
             $post_types = ['post'];
         }
 
-        $post_types = array_map('esc_sql', $post_types);
-        $post_types_in = "'" . implode("','", $post_types) . "'";
+        $post_types = array_values(array_filter(array_map('sanitize_key', $post_types)));
+        $post_types_placeholders = implode(', ', array_fill(0, count($post_types), '%s'));
+        $query_args = array_merge([$user_id], $post_types);
 
-        $count = (int) $wpdb->get_var($wpdb->prepare(
+        $count = (int) $wpdb->get_var(
+            // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Post type placeholders are generated from a sanitized array.
+            $wpdb->prepare(
             "SELECT COUNT(*) FROM {$wpdb->posts}
             WHERE post_author = %d
-            AND post_type IN ({$post_types_in})
+            AND post_type IN ({$post_types_placeholders})
             AND post_status = 'publish'",
-            $user_id
-        ));
+                $query_args
+            )
+            // phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+        );
 
         return $count;
     }

--- a/tests/codeception/wpunit/core/Classes/InstallerCest.php
+++ b/tests/codeception/wpunit/core/Classes/InstallerCest.php
@@ -290,6 +290,19 @@ class InstallerCest
         $I->assertEquals($post->post_author, $usersWithNoTerms[3]);
     }
 
+    public function getUsersAuthorsWithNoAuthorTerm__withZeroPostsPerPage__returnsNoResults(WpunitTester $I)
+    {
+        $I->havePostsWithDifferentAuthors(2);
+
+        $usersWithNoTerms = Installer::getUsersAuthorsWithNoAuthorTerm(
+            [
+                'posts_per_page' => 0,
+            ]
+        );
+
+        $I->assertSame([], $usersWithNoTerms);
+    }
+
     public function getUsersAuthorsWithNoAuthorTerm__withPaged__returnsListOfUsersLimitedToTheSpecifiedNumber(
         WpunitTester $I
     ) {
@@ -391,6 +404,33 @@ class InstallerCest
         $I->assertEquals($postIds[9], $postsWithNoTerm[0]->ID);
     }
 
+    public function getPostsWithoutAuthorTerms__withPreviouslySupportedOrderByColumn__returnsOnCorrectOrder(
+        WpunitTester $I
+    ) {
+        $postIds = $I->havePostsWithDifferentAuthors(4);
+
+        foreach ($postIds as $menuOrder => $postId) {
+            wp_update_post(
+                [
+                    'ID'         => $postId,
+                    'menu_order' => $menuOrder,
+                ]
+            );
+        }
+
+        $postsWithNoTerm = Installer::getPostsWithoutAuthorTerms(
+            [
+                'orderby' => 'menu_order',
+                'order'   => 'desc',
+            ]
+        );
+
+        $I->assertSame(
+            array_reverse($postIds),
+            array_map('intval', wp_list_pluck($postsWithNoTerm, 'ID'))
+        );
+    }
+
     public function getPostsWithoutAuthorTerms__withPostPorPageArgument__returnsOnlyTheSpecifiedNumberOfResults(
         WpunitTester $I
     ) {
@@ -406,6 +446,19 @@ class InstallerCest
         $I->assertCount(2, $postsWithNoTerm);
         $I->assertEquals($postIds[6], $postsWithNoTerm[0]->ID);
         $I->assertEquals($postIds[7], $postsWithNoTerm[1]->ID);
+    }
+
+    public function getPostsWithoutAuthorTerms__withZeroPostsPerPage__returnsNoResults(WpunitTester $I)
+    {
+        $I->havePostsWithDifferentAuthors(2);
+
+        $postsWithNoTerm = Installer::getPostsWithoutAuthorTerms(
+            [
+                'posts_per_page' => 0,
+            ]
+        );
+
+        $I->assertSame([], $postsWithNoTerm);
     }
 
     public function getPostsWithoutAuthorTerms__withPagedArgument__returnsOnlyTheSpecifiedNumberOfResults(


### PR DESCRIPTION
## Summary
- Prepare legacy installer migration queries with generated post type placeholders and integer limits
- Whitelist installer ordering fields and sanitize post type arrays
- Fix core author count/get_page_by_title query preparation warnings while preserving filter compatibility

## Tests
- `vendor/bin/phpcs --standard=phpcs.xml --sniffs=WordPress.DB.PreparedSQL,WordPress.DB.PreparedSQLPlaceholders --report=json src/core/Classes/Installer.php src/core/Classes/Utils.php src/core/Plugin.php src/core/Classes/Objects/Author.php`
- `php -l src/core/Classes/Installer.php && php -l src/core/Classes/Utils.php && php -l src/core/Plugin.php && php -l src/core/Classes/Objects/Author.php`
- Combined validation branch: targeted SQL PHPCS across all screenshot files returned 0 errors