### PR TITLE
Fix sync post author SQL preparation

### DIFF
--- a/src/modules/multiple-authors/multiple-authors.php
+++ b/src/modules/multiple-authors/multiple-authors.php
@@ -4362,6 +4362,7 @@ echo '<span class="ppma_settings_field_description">'
             )));
 
             if (empty($postTypes)) {
+                delete_transient('publishpress_authors_sync_post_author_ids');
                 wp_send_json(['total' => 0]);
             }
 

--- a/src/modules/multiple-authors/multiple-authors.php
+++ b/src/modules/multiple-authors/multiple-authors.php
@@ -4356,11 +4356,25 @@ echo '<span class="ppma_settings_field_description">'
                 wp_send_json_error(null, 403);
             }
 
-            $postTypes = array_values(Util::get_post_types_for_module($this->module));
-            $postTypes = '"' . implode('","', $postTypes) . '"';
+            $postTypes = array_values(array_filter(array_map(
+                'sanitize_key',
+                Util::get_post_types_for_module($this->module)
+            )));
+
+            if (empty($postTypes)) {
+                wp_send_json(['total' => 0]);
+            }
+
+            $postTypePlaceholders = implode(', ', array_fill(0, count($postTypes), '%s'));
 
             $result = $wpdb->get_results(
-                "SELECT ID FROM {$wpdb->posts} WHERE post_type IN ({$postTypes}) AND post_status NOT IN ('trash')",
+                // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Post type placeholders are generated from a sanitized array.
+                $wpdb->prepare(
+                    "SELECT ID FROM {$wpdb->posts} WHERE post_type IN ({$postTypePlaceholders}) AND post_status NOT IN ('trash')",
+                    $postTypes
+                )
+                // phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+                ,
                 ARRAY_N
             );
 

--- a/tests/codeception/wpunit/modules/multiple_authors/MultipleAuthorsCest.php
+++ b/tests/codeception/wpunit/modules/multiple_authors/MultipleAuthorsCest.php
@@ -146,4 +146,43 @@ class MultipleAuthorsCest
             $receivers
         );
     }
+
+    public function testGetSyncPostAuthorDataWithNoPostTypesClearsStalePostIds(WpunitTester $I)
+    {
+        $module = $this->getMultipleAuthorsModule();
+        $originalPostTypes = $module->module->options->post_types;
+        $originalUserId = get_current_user_id();
+        $dieHandler = static function () {
+            return static function () {
+                throw new \RuntimeException('wp_send_json completed');
+            };
+        };
+
+        $adminUserId = $I->factory('an admin user')->user->create(['role' => 'administrator']);
+        wp_set_current_user($adminUserId);
+        $module->module->options->post_types = [];
+        set_transient('publishpress_authors_sync_post_author_ids', [123, 456], HOUR_IN_SECONDS);
+        $_GET['nonce'] = wp_create_nonce('sync_post_author');
+
+        add_filter('wp_die_handler', $dieHandler, PHP_INT_MAX);
+        add_filter('wp_die_ajax_handler', $dieHandler, PHP_INT_MAX);
+        ob_start();
+
+        try {
+            $module->getSyncPostAuthorData();
+            $I->fail('Expected wp_send_json() to terminate the request.');
+        } catch (\RuntimeException $exception) {
+            $I->assertSame('wp_send_json completed', $exception->getMessage());
+        } finally {
+            $response = ob_get_clean();
+            remove_filter('wp_die_handler', $dieHandler, PHP_INT_MAX);
+            remove_filter('wp_die_ajax_handler', $dieHandler, PHP_INT_MAX);
+            unset($_GET['nonce']);
+            $module->module->options->post_types = $originalPostTypes;
+            wp_set_current_user($originalUserId);
+        }
+
+        $I->assertSame(['total' => 0], json_decode($response, true));
+        $I->assertFalse(get_transient('publishpress_authors_sync_post_author_ids'));
+    }
 }


### PR DESCRIPTION
## Summary
- Sanitize module post types before querying posts for sync data
- Generate prepared placeholders for the post type IN clause
- Return an empty sync total when no post types are enabled

## Tests
- `vendor/bin/phpcs --standard=phpcs.xml --sniffs=WordPress.DB.PreparedSQL,WordPress.DB.PreparedSQLPlaceholders --report=json src/modules/multiple-authors/multiple-authors.php`
- `php -l src/modules/multiple-authors/multiple-authors.php`
- Combined validation branch: targeted SQL PHPCS across all screenshot files returned 0 errors